### PR TITLE
COGNIREPO-D01: restore find_symbol_path and get_service_endpoints to manifest.json/glama.json

### DIFF
--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -1,5 +1,5 @@
 epic_id: COGNIREPO-100
-status: not-started
+status: in-progress
 stories:
   - id: COGNIREPO-101
     status: not-started
@@ -33,10 +33,10 @@ stories:
     test_status: not-run
 defects:
   - id: COGNIREPO-D01
-    status: not-started
+    status: in-review
     branch: defect/COGNIREPO-D01
-    pr: null
-    test_status: not-run
+    pr: https://github.com/ashlesh-t/cognirepo/pull/32
+    test_status: pass
   - id: COGNIREPO-D02
     status: not-started
     branch: defect/COGNIREPO-D02

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -4,7 +4,7 @@ active_epic: COGNIREPO-100
 epics:
   - id: COGNIREPO-100
     name: ReliabilityGate
-    status: not-started
+    status: in-progress
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening

--- a/glama.json
+++ b/glama.json
@@ -568,7 +568,7 @@
           "limit": {
             "type": "integer",
             "description": "Max sessions to return",
-            "default": 5
+            "default": 10
           }
         }
       }
@@ -678,6 +678,48 @@
             "type": "string",
             "description": "Absolute path to target repository (optional)",
             "default": null
+          }
+        }
+      }
+    },
+    {
+      "name": "find_symbol_path",
+      "description": "Find the shortest call-graph path between two symbols, crossing service boundaries via the org graph when needed.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "from_symbol": {
+            "type": "string",
+            "description": "Name of the source symbol"
+          },
+          "to_symbol": {
+            "type": "string",
+            "description": "Name of the destination symbol"
+          },
+          "from_repo": {
+            "type": "string",
+            "description": "Absolute path to source repo (auto-detected if omitted)",
+            "default": ""
+          },
+          "to_repo": {
+            "type": "string",
+            "description": "Absolute path to destination repo (auto-detected if omitted)",
+            "default": ""
+          }
+        },
+        "required": ["from_symbol", "to_symbol"]
+      }
+    },
+    {
+      "name": "get_service_endpoints",
+      "description": "Return the HTTP endpoint registry for a service (from endpoints.json).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repo_path": {
+            "type": "string",
+            "description": "Absolute path to the target repo (defaults to current project)",
+            "default": ""
           }
         }
       }

--- a/interface/server/manifest.json
+++ b/interface/server/manifest.json
@@ -15,7 +15,7 @@
           },
           "source": {
             "type": "string",
-            "description": "Origin label (file, url, …)",
+            "description": "Origin label (file, url, \u2026)",
             "default": ""
           },
           "repo_path": {
@@ -557,7 +557,7 @@
     },
     {
       "name": "search_token",
-      "description": "Fast BM25 token search over symbol names and docs — no embedding needed.",
+      "description": "Fast BM25 token search over symbol names and docs \u2014 no embedding needed.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -592,7 +592,7 @@
     },
     {
       "name": "get_last_context",
-      "description": "Return what the last agent was looking at — resume from cross-agent handoff.",
+      "description": "Return what the last agent was looking at \u2014 resume from cross-agent handoff.",
       "parameters": {
         "type": "object",
         "properties": {}
@@ -607,7 +607,7 @@
           "limit": {
             "type": "integer",
             "description": "Max sessions to return",
-            "default": 5
+            "default": 10
           }
         }
       }
@@ -722,6 +722,51 @@
             "type": "string",
             "description": "Absolute path to target repository (optional)",
             "default": null
+          }
+        }
+      }
+    },
+    {
+      "name": "find_symbol_path",
+      "description": "Find the shortest call-graph path between two symbols, crossing service boundaries via the org graph when needed.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "from_symbol": {
+            "type": "string",
+            "description": "Name of the source symbol"
+          },
+          "to_symbol": {
+            "type": "string",
+            "description": "Name of the destination symbol"
+          },
+          "from_repo": {
+            "type": "string",
+            "description": "Absolute path to source repo (auto-detected if omitted)",
+            "default": ""
+          },
+          "to_repo": {
+            "type": "string",
+            "description": "Absolute path to destination repo (auto-detected if omitted)",
+            "default": ""
+          }
+        },
+        "required": [
+          "from_symbol",
+          "to_symbol"
+        ]
+      }
+    },
+    {
+      "name": "get_service_endpoints",
+      "description": "Return the HTTP endpoint registry for a service (from endpoints.json).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "repo_path": {
+            "type": "string",
+            "description": "Absolute path to the target repo (defaults to current project)",
+            "default": ""
           }
         }
       }

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -2510,7 +2510,7 @@ def _build_manifest() -> dict:
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "limit": {"type": "integer", "description": "Max sessions to return", "default": 5},
+                        "limit": {"type": "integer", "description": "Max sessions to return", "default": 10},
                     },
                 },
             },
@@ -2571,6 +2571,45 @@ def _build_manifest() -> dict:
                     "properties": {
                         "min_count": {"type": "integer", "description": "Only return errors seen at least this many times", "default": 1},
                         "repo_path": {"type": "string", "description": "Absolute path to target repository (optional)", "default": None},
+                    },
+                },
+            },
+            {
+                "name": "find_symbol_path",
+                "description": (
+                    "Find the shortest call-graph path between two symbols, crossing service "
+                    "boundaries via the org graph when needed."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "from_symbol": {"type": "string", "description": "Name of the source symbol"},
+                        "to_symbol": {"type": "string", "description": "Name of the destination symbol"},
+                        "from_repo": {
+                            "type": "string",
+                            "description": "Absolute path to source repo (auto-detected if omitted)",
+                            "default": "",
+                        },
+                        "to_repo": {
+                            "type": "string",
+                            "description": "Absolute path to destination repo (auto-detected if omitted)",
+                            "default": "",
+                        },
+                    },
+                    "required": ["from_symbol", "to_symbol"],
+                },
+            },
+            {
+                "name": "get_service_endpoints",
+                "description": "Return the HTTP endpoint registry for a service (from endpoints.json).",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "repo_path": {
+                            "type": "string",
+                            "description": "Absolute path to the target repo (defaults to current project)",
+                            "default": "",
+                        },
                     },
                 },
             },


### PR DESCRIPTION
## Summary
- Restores `find_symbol_path` and `get_service_endpoints` to `manifest.json` and `glama.json` — the [1.1.3] fix for exactly these two tools was silently dropped by the 2.0.0 layer-restructure rewrite of `_build_manifest()`. `_REGISTERED_TOOLS` (used by `doctor`'s schema check) already had all 34 tools, which masked the regression from `cognirepo doctor`.
- Corrects the stale `get_session_history` `limit` default (5 → 10) in both artifacts to match the code (`mcp_server.py:1697`).
- `manifest.json` regenerated via `_write_manifest()`.

Ticket: `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D01/COGNIREPO-D01.md`

## Acceptance criteria
- [x] manifest.json and glama.json list 34 tools; set-equal with decorators.
- [x] `cognirepo doctor`'s MCP tool schema check passes (all `_REGISTERED_TOOLS` present in both artifacts).
- [x] Entries' parameter schemas match the Python signatures (name/type/default).

## Test plan
- [x] Full pytest suite: 1203 passed, 5 skipped (unchanged from baseline)
- [x] Manual verification: `_REGISTERED_TOOLS` (34) == manifest.json tool names (34) == glama.json tool names (34), diff is empty set
- [x] `find_symbol_path`/`get_service_endpoints` schemas checked against Python signatures
- [x] `get_session_history` limit default = 10 in manifest.json, glama.json, and code
- See `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D01/TEST/COGNIREPO-D01-TEST_SUITE.md` for full results (Verdict: PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)