### PR TITLE
COGNIREPO-D03: revert requirements.txt CVE downgrade, audit pins in CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install pip-audit
         run: pip install pip-audit
 
-      - name: Run pip-audit
+      - name: Run pip-audit (pyproject install)
         run: |
           pip install --upgrade pip --quiet
           pip install . --quiet
@@ -49,6 +49,18 @@ jobs:
           # and CogniRepo does not process untrusted code snippets with that lexer.
           # Ignore CVE-2026-3219 (pip itself): resolved by the pip upgrade above; pip is not a runtime dep.
           pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
+
+      - name: Run pip-audit (requirements.txt pins)
+        run: |
+          # Audits the pinned versions in requirements.txt directly — `pip install .`
+          # above resolves from pyproject.toml and does not exercise these pins, so a
+          # CVE fix committed to requirements.txt could silently drift without this step.
+          # Ignore CVE-2026-45829 (chromadb pre-auth code injection via trust_remote_code on
+          # its HTTP server's /collections endpoint): CogniRepo only uses
+          # chromadb.PersistentClient (embedded, in-process — core/vector_db/chroma_adapter.py),
+          # never chromadb's HTTP server, so the vulnerable endpoint is never running.
+          pip-audit -r requirements.txt \
+            --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829
 
   # ── 3. Trivy — filesystem scan ────────────────────────────────────────────
   trivy:

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/COGNIREPO-D03.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/COGNIREPO-D03.md
@@ -27,3 +27,42 @@ Evidence: ../../COGNIREPO-100-Discovery.md §5.
    acceptance of the downgrade is recorded in this ticket.
 2. security.yml audits requirements.txt pins; CI green.
 3. `pip install -r requirements.txt` + full pytest green on the resulting pins.
+
+## Resolution (2026-07-13)
+User's initial recollection: cryptography 48.0.1 "was giving some error, mostly some security
+issue" on install, requiring the downgrade to 47.0.0. Investigation: `pip install
+cryptography==48.0.1` (and PyJWT==2.13.0, starlette==1.3.1, urllib3==2.7.0) reproduced cleanly
+in this environment — all four resolve to prebuilt manylinux wheels, no Rust/OpenSSL build step,
+no install error. Full pytest (1203 passed, 5 skipped) green with all four at the CVE-fixed
+pins. User confirmed the recollection was an install/build-type error, which did not reproduce
+here — **decision: revert to the CVE-fixed pins** (`git checkout -- requirements.txt`),
+restoring cryptography==48.0.1, PyJWT==2.13.0, starlette==1.3.1, urllib3==2.7.0. This
+re-resolves GHSA-537c-gmf6-5ccf.
+
+**Root cause of the original drift**: `.claude/settings.local.json` has a PostToolUse hook that
+runs `pip freeze --exclude-editable > requirements.txt` after any `pip install`. An earlier
+ad-hoc `pip install` (unrelated to these four packages) resolved older transitive pins into the
+venv and the hook silently froze them into requirements.txt. This hook is a deliberate
+project convention (auto-sync requirements.txt to the dev venv) — noted here, not changed by
+this defect, but it means any manual `pip install` during future dev work can reintroduce drift
+unless the venv itself is kept clean of scratch/audit-only tooling before running one.
+
+**Additional CVEs found by the new `pip-audit -r requirements.txt` step** (AC2) that the
+existing `pip install .` (pyproject-based) job never audited:
+- `chromadb` 1.5.8 → CVE-2026-45829 / PYSEC-2026-311 (pre-auth code injection via
+  `trust_remote_code` on chromadb's HTTP server `/collections` endpoint). No fixed version
+  exists yet (last_affected 1.5.9, current latest). **Not exploitable here**: CogniRepo only
+  uses `chromadb.PersistentClient` (embedded, in-process — `core/vector_db/chroma_adapter.py:60`,
+  `interface/cli/main.py:410`), never chromadb's HTTP server — the vulnerable endpoint never
+  runs. Bumped to 1.5.9 (latest) anyway; added as a third documented ignore in security.yml.
+  **Separate pre-existing issue, out of scope here**: `chromadb` is used by real code but is not
+  declared in pyproject.toml's `dependencies` — undeclared-dependency bug, worth its own ticket.
+- `idna` 3.11 → PYSEC-2026-215, fixed in 3.15+. Bumped to 3.18 (latest).
+- `pydantic-settings` 2.13.1 → GHSA-4xgf-cpjx-pc3j, fixed in 2.14.2. Bumped to 2.14.2.
+- `python-multipart` 0.0.30 → CVE-2026-53540, fixed in 0.0.31. The original (rejected)
+  working-tree diff's bump to 0.0.32 was, incidentally, a real CVE fix — kept at 0.0.32.
+- `pillow` 12.2.0 → 5 CVEs (PYSEC-2026-2253/2254/2255/2256/2257, decompression-bomb-style DoS in
+  font/image parsing), fixed in 12.3.0. Bumped to 12.3.0.
+
+Final pip-audit (`-r requirements.txt`, 3 documented ignores): clean. Full pytest: 1203 passed,
+5 skipped (unchanged from baseline).

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/TEST/COGNIREPO-D03-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/TEST/COGNIREPO-D03-TEST_SUITE.md
@@ -12,5 +12,12 @@
   pass.
 - Obtained results (reproduction at HEAD pre-fix, 2026-07-11): working-tree diff present,
   reverting pins from commits 779b113/6083b15; pip-audit not runnable offline in the audit
-  session. Fix verification: (empty)
-- Verdict:
+  session. Fix verification (post-fix, defect/COGNIREPO-D03, 2026-07-13): requirements.txt
+  restored to cryptography==48.0.1, PyJWT==2.13.0, starlette==1.3.1, urllib3==2.7.0 (matches
+  committed CVE-fixed pins); additionally bumped chromadb==1.5.9, idna==3.18,
+  pydantic-settings==2.14.2, python-multipart==0.0.32, pillow==12.3.0 to close CVEs surfaced by
+  the new requirements.txt audit step. `pip-audit -r requirements.txt` with the 3 documented
+  ignores (CVE-2026-4539, CVE-2026-3219, CVE-2026-45829): "No known vulnerabilities found, 1
+  ignored". Full pytest: 1203 passed, 5 skipped (unchanged from baseline). security.yml now
+  runs a second pip-audit step against requirements.txt pins.
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -43,8 +43,8 @@ defects:
     pr: null
     test_status: not-run
   - id: COGNIREPO-D03
-    status: not-started
+    status: in-review
     branch: defect/COGNIREPO-D03
-    pr: null
-    test_status: not-run
+    pr: https://github.com/ashlesh-t/cognirepo/pull/33
+    test_status: pass
 epic_test_suite_status: not-run

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ build==1.4.4
 certifi==2026.2.25
 cffi==2.0.0
 charset-normalizer==3.4.6
-chromadb==1.5.8
+chromadb==1.5.9
 click==8.3.3
 coverage==7.13.5
 cryptography==48.0.1
@@ -43,7 +43,7 @@ httptools==0.7.1
 httpx==0.28.1
 httpx-sse==0.4.3
 huggingface_hub==1.8.0
-idna==3.11
+idna==3.18
 importlib_metadata==8.7.1
 importlib_resources==7.1.0
 iniconfig==2.3.0
@@ -81,7 +81,7 @@ orjson==3.11.8
 overrides==7.7.0
 packaging==26.0
 passlib==1.7.4
-pillow==12.2.0
+pillow==12.3.0
 pluggy==1.6.0
 prometheus_client==0.25.0
 proto-plus==1.27.2
@@ -93,7 +93,7 @@ pyasn1_modules==0.4.2
 pybase64==1.4.3
 pycparser==3.0
 pydantic==2.13.3
-pydantic-settings==2.13.1
+pydantic-settings==2.14.2
 pydantic_core==2.46.3
 Pygments==2.20.0
 PyJWT==2.13.0
@@ -108,7 +108,7 @@ pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-python-multipart==0.0.30
+python-multipart==0.0.32
 PyYAML==6.0.3
 rank-bm25==0.2.2
 redis==7.4.0


### PR DESCRIPTION
## Summary
- Reverts the uncommitted `requirements.txt` diff that downgraded `cryptography` (48.0.1→47.0.0, reintroducing **GHSA-537c-gmf6-5ccf**), `PyJWT`, `starlette`, and `urllib3` below their CVE-fixed committed pins (779b113, 6083b15). The install error that motivated the downgrade did not reproduce in this environment (clean manylinux wheels, full pytest green) — user confirmed and approved the revert. See ticket's "Resolution" section for the full investigation.
- Root cause of the drift, documented in the ticket: a PostToolUse hook in `.claude/settings.local.json` re-freezes `requirements.txt` after any `pip install`; an unrelated ad-hoc install silently pulled the downgrade in.
- Adds a second `pip-audit` step to `security.yml` that audits `requirements.txt` pins directly — the existing step only audits `pip install .` (pyproject.toml), which never exercises this file, so a future CVE fix committed here could silently drift undetected.
- That new step immediately surfaced 5 more real CVEs this file's drift had been masking — all bumped to fixed versions: `chromadb` (CVE-2026-45829 — no fix available upstream yet, ignored with justification since CogniRepo only uses `chromadb.PersistentClient`, never chromadb's HTTP server), `idna` (PYSEC-2026-215), `pydantic-settings` (GHSA-4xgf-cpjx-pc3j), `python-multipart` (CVE-2026-53540), `pillow` (5 CVEs, decompression-bomb DoS in font/image parsing).

Ticket: `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/COGNIREPO-D03.md`

## Acceptance criteria
- [x] requirements.txt matches (exceeds, for the 5 newly-found CVEs) the CVE-fixed committed pins; user's decision recorded in the ticket.
- [x] security.yml audits requirements.txt pins.
- [x] `pip install -r requirements.txt` + full pytest green on the resulting pins.

## Test plan
- [x] `pip-audit -r requirements.txt` with 3 documented ignores: "No known vulnerabilities found, 1 ignored"
- [x] Full pytest suite: 1203 passed, 5 skipped (unchanged from baseline)
- [x] Verified all 9 changed/reverted pins install cleanly via prebuilt wheels (no Rust/OpenSSL build step)
- See `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D03/TEST/COGNIREPO-D03-TEST_SUITE.md` for full results (Verdict: PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)