### PR TITLE
COGNIREPO-104: verify-index working-tree staleness detection

### DIFF
--- a/JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-104/TEST/COGNIREPO-104-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-104/TEST/COGNIREPO-104-TEST_SUITE.md
@@ -8,5 +8,11 @@
   exit codes and outputs."
 - Expected results: first run OK/exit 0; second run DIRTY line naming 1 file, exit 1; after
   `git checkout` of the file, OK again.
-- Obtained results:
-- Verdict:
+- Obtained results: Ran against `cognirepo_test_repo/easy/flask` (existing index: 1832 symbols ·
+  92 files · commit `2ac89889f4cc`). First `verify-index`: `OK 1832 symbols · 92 files · commit
+  2ac89889f4cc · indexed 2026-07-16T18:31:51.077693+00:00`, exit 0. Appended a comment line to
+  the tracked, indexed `docs/conf.py`; re-ran after the ±2s clock-skew window: `OK` line
+  unchanged plus a new `DIRTY  1 uncommitted indexed source file(s) newer than index` line
+  naming `docs/conf.py`, with the rebuild hint, exit 1. Ran `git checkout -- docs/conf.py` to
+  discard the edit; re-ran `verify-index`: back to plain `OK`, exit 0, no DIRTY line.
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -19,7 +19,7 @@ stories:
   - id: COGNIREPO-104
     status: in-review
     branch: story/COGNIREPO-104
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/38
     test_status: pass
   - id: COGNIREPO-105
     status: not-started

--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -17,10 +17,10 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/37
     test_status: pass
   - id: COGNIREPO-104
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-104
     pr: null
-    test_status: not-run
+    test_status: pass
   - id: COGNIREPO-105
     status: not-started
     branch: story/COGNIREPO-105

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -139,13 +139,15 @@ def _direct_search(query):
     return search_docs(query)
 
 
-def _cmd_verify_index() -> int:
+def _cmd_verify_index(verbose: bool = False) -> int:
     """
     Verify AST index integrity against manifest.json.
 
     Exit codes:
       0 — index is OK and matches the current git HEAD
-      1 — index is STALE (source changed since last index) or CORRUPTED
+      1 — index is STALE (source changed since last index) or CORRUPTED, or the
+          working tree has uncommitted edits to indexed sources newer than the
+          index (DIRTY)
       2 — manifest not found (run `cognirepo index-repo .` first)
     """
     # pylint: disable=import-outside-toplevel
@@ -240,6 +242,45 @@ def _cmd_verify_index() -> int:
                 issues += 1
         except Exception:  # pylint: disable=broad-except
             print(f"  OK             index at commit {manifest_commit[:12]} (no git to compare)")
+
+    # ── Working-tree staleness (uncommitted edits to indexed sources) ──────
+    if not corrupted:
+        try:
+            import subprocess as _sp  # pylint: disable=import-outside-toplevel
+            from datetime import datetime as _datetime  # pylint: disable=import-outside-toplevel
+            from intelligence.indexer.language_registry import is_supported  # pylint: disable=import-outside-toplevel
+
+            indexed_at_raw = manifest.get("indexed_at", "")
+            indexed_at_ts = _datetime.fromisoformat(indexed_at_raw).timestamp()
+
+            status_out = _sp.check_output(
+                ["git", "status", "--porcelain"], stderr=_sp.DEVNULL
+            ).decode()
+
+            dirty = []
+            for line in status_out.splitlines():
+                rel_path = line[3:].strip()
+                if " -> " in rel_path:  # renamed entries: "old -> new"
+                    rel_path = rel_path.split(" -> ", 1)[1]
+                if not is_supported(rel_path) or not os.path.exists(rel_path):
+                    continue
+                if os.path.getmtime(rel_path) > indexed_at_ts + 2:  # ±2s clock-skew tolerance
+                    dirty.append(rel_path)
+
+            if dirty:
+                print(
+                    f"  DIRTY          {len(dirty)} uncommitted indexed source file(s) "
+                    "newer than index"
+                )
+                shown = dirty if verbose else dirty[:5]
+                for p in shown:
+                    print(f"                   {p}")
+                if not verbose and len(dirty) > 5:
+                    print(f"                   ... and {len(dirty) - 5} more (use -v to list all)")
+                print("  → Re-run `cognirepo index-repo .` to update, or commit/stash the edits.")
+                issues += 1
+        except Exception:  # pylint: disable=broad-except
+            pass  # non-git directory or unparsable indexed_at — degrade gracefully, no DIRTY check
 
     return 1 if issues else 0
 
@@ -3171,9 +3212,15 @@ def _main():
     )
 
     # verify-index — check index integrity against manifest
-    sub.add_parser(
+    p_verify_index = sub.add_parser(
         "verify-index",
         help="Verify that the AST index is fresh and untampered (checks manifest.json)",
+    )
+    p_verify_index.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        default=False,
+        help="List all dirty indexed files, not just the first 5.",
     )
 
     # coverage — show per-directory symbol counts
@@ -3813,7 +3860,7 @@ def _main():
         return
 
     if args.command == "verify-index":
-        sys.exit(_cmd_verify_index())
+        sys.exit(_cmd_verify_index(verbose=args.verbose))
 
     if args.command == "summarize":
         from intelligence.indexer.summarizer import SummarizationEngine  # pylint: disable=import-outside-toplevel

--- a/tests/test_verify_index_dirty.py
+++ b/tests/test_verify_index_dirty.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+"""
+tests/test_verify_index_dirty.py — COGNIREPO-104: verify-index working-tree
+staleness detection.
+
+Exercises _cmd_verify_index() against a real git repo (isolated_cognirepo fixture
+chdirs into tmp_path) so `git status --porcelain` and mtime comparisons are real,
+not mocked.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import time
+from datetime import datetime, timezone
+
+import faiss
+import pytest
+
+
+def _sh(*args):
+    subprocess.run(["git", *args], check=True, capture_output=True)
+
+
+def _init_git_repo():
+    _sh("init", "-q")
+    _sh("config", "user.email", "test@example.com")
+    _sh("config", "user.name", "Test")
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+
+def _write_manifest(indexed_at: str | None = None):
+    """Write real index files + a manifest.json that verify-index will accept as OK."""
+    from core.config.paths import get_path
+    from intelligence.indexer.ast_indexer import (
+        _ast_index_file, _ast_faiss_file, _ast_meta_file, _manifest_file,
+    )
+
+    os.makedirs(get_path("index"), exist_ok=True)
+    for f in (_ast_index_file(), _ast_faiss_file(), _ast_meta_file()):
+        with open(f, "w", encoding="utf-8") as fh:
+            fh.write("stub")
+
+    git_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    manifest = {
+        "platform": {"arch": platform.machine(), "faiss": faiss.__version__},
+        "index_checksums": {
+            "ast_index.json": _sha256(_ast_index_file()),
+            "ast.index": _sha256(_ast_faiss_file()),
+            "ast_metadata.json": _sha256(_ast_meta_file()),
+        },
+        "git_commit": git_commit,
+        "indexed_at": indexed_at or datetime.now(tz=timezone.utc).isoformat(),
+        "source_file_count": 1,
+        "symbol_count": 1,
+    }
+    with open(_manifest_file(), "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)
+    return git_commit
+
+
+class TestVerifyIndexDirtyDetection:
+    def test_clean_tree_is_ok_exit_0(self):
+        from interface.cli.main import _cmd_verify_index
+
+        _init_git_repo()
+        with open("mod.py", "w", encoding="utf-8") as f:
+            f.write("def foo(): pass\n")
+        _sh("add", "-A")
+        _sh("commit", "-q", "-m", "init")
+
+        _write_manifest()
+
+        code = _cmd_verify_index()
+        assert code == 0
+
+    def test_dirty_indexed_py_file_flagged(self, capsys):
+        from interface.cli.main import _cmd_verify_index
+
+        _init_git_repo()
+        with open("mod.py", "w", encoding="utf-8") as f:
+            f.write("def foo(): pass\n")
+        _sh("add", "-A")
+        _sh("commit", "-q", "-m", "init")
+
+        # index built "in the past" so the edit below is unambiguously newer
+        _write_manifest(indexed_at=datetime.now(tz=timezone.utc).isoformat())
+        time.sleep(2.5)  # clear the ±2s clock-skew tolerance window
+
+        with open("mod.py", "a", encoding="utf-8") as f:
+            f.write("def bar(): pass\n")
+
+        code = _cmd_verify_index()
+        out = capsys.readouterr().out
+
+        assert code == 1
+        assert "DIRTY" in out
+        assert "mod.py" in out
+
+    def test_dirty_non_indexed_extension_not_flagged(self, capsys):
+        from interface.cli.main import _cmd_verify_index
+
+        _init_git_repo()
+        with open("mod.py", "w", encoding="utf-8") as f:
+            f.write("def foo(): pass\n")
+        with open("README.md", "w", encoding="utf-8") as f:
+            f.write("# hi\n")
+        _sh("add", "-A")
+        _sh("commit", "-q", "-m", "init")
+
+        _write_manifest()
+        time.sleep(2.5)
+
+        with open("README.md", "a", encoding="utf-8") as f:
+            f.write("more docs\n")
+
+        code = _cmd_verify_index()
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "DIRTY" not in out
+
+    def test_non_git_directory_degrades_gracefully(self, capsys):
+        from interface.cli.main import _cmd_verify_index
+
+        # No `git init` — repo root is a plain directory.
+        _write_manifest_no_git()
+
+        code = _cmd_verify_index()
+        out = capsys.readouterr().out
+
+        assert code in (0, 1)  # must not raise
+        assert "DIRTY" not in out
+
+    def test_verbose_lists_more_than_five_dirty_files(self, capsys):
+        from interface.cli.main import _cmd_verify_index
+
+        _init_git_repo()
+        for i in range(7):
+            with open(f"mod{i}.py", "w", encoding="utf-8") as f:
+                f.write("def foo(): pass\n")
+        _sh("add", "-A")
+        _sh("commit", "-q", "-m", "init")
+
+        _write_manifest()
+        time.sleep(2.5)
+
+        for i in range(7):
+            with open(f"mod{i}.py", "a", encoding="utf-8") as f:
+                f.write("def bar(): pass\n")
+
+        code = _cmd_verify_index(verbose=True)
+        out = capsys.readouterr().out
+
+        assert code == 1
+        for i in range(7):
+            assert f"mod{i}.py" in out
+
+
+def _write_manifest_no_git():
+    """Manifest with an unresolvable git_commit — mirrors a non-git working dir."""
+    from core.config.paths import get_path
+    from intelligence.indexer.ast_indexer import (
+        _ast_index_file, _ast_faiss_file, _ast_meta_file, _manifest_file,
+    )
+
+    os.makedirs(get_path("index"), exist_ok=True)
+    for f in (_ast_index_file(), _ast_faiss_file(), _ast_meta_file()):
+        with open(f, "w", encoding="utf-8") as fh:
+            fh.write("stub")
+
+    manifest = {
+        "platform": {"arch": platform.machine(), "faiss": faiss.__version__},
+        "index_checksums": {
+            "ast_index.json": _sha256(_ast_index_file()),
+            "ast.index": _sha256(_ast_faiss_file()),
+            "ast_metadata.json": _sha256(_ast_meta_file()),
+        },
+        "git_commit": "unknown",
+        "indexed_at": datetime.now(tz=timezone.utc).isoformat(),
+        "source_file_count": 0,
+        "symbol_count": 0,
+    }
+    with open(_manifest_file(), "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh)


### PR DESCRIPTION
Ticket: `JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-104/COGNIREPO-104.md`

## Acceptance criteria
- [x] AC1 — Clean tree at indexed commit → unchanged OK output, exit 0.
- [x] AC2 — One uncommitted edit to an indexed `.py` → DIRTY line, exit 1.
- [x] AC3 — Edit to a non-indexed extension (`.md`) → no DIRTY, exit 0.
- [x] AC4 — Non-git directory degrades gracefully (existing behavior preserved).

## Changes
- `interface/cli/main.py`: `_cmd_verify_index()` runs `git status --porcelain` after the existing checksum/commit checks, filters to indexed extensions via `language_registry.is_supported`, and flags dirty tracked files whose mtime is newer than the manifest's `indexed_at` (±2s clock-skew tolerance) as `DIRTY`. Lists up to 5 paths by default; new `-v/--verbose` flag on `verify-index` lists all.
- Exit codes unchanged in shape: 0 OK, 1 stale/corrupted/dirty, 2 no manifest.

## Test plan
- [x] `venv/bin/python -m pytest tests/ -q` — 1227 passed, 5 skipped, 0 failed
- [x] `tests/test_verify_index_dirty.py` — real git repo, drives all 4 ACs + verbose listing
- [x] Manual TEST_SUITE (`STORY/COGNIREPO-104/TEST/COGNIREPO-104-TEST_SUITE.md`): TC-104-1 PASS, run against `cognirepo_test_repo/easy/flask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)