### PR TITLE
COGNIREPO-D04/D05/D06/D07/D08: fix defects found during COGNIREPO-105, unblock TC-105-1

### DIFF
--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D04/TEST/COGNIREPO-D04-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D04/TEST/COGNIREPO-D04-TEST_SUITE.md
@@ -8,5 +8,14 @@
 - Prompt: n/a — automated via tests/test_behaviour_tracker.py (direct call, no mock).
 - Expected results: summarize_interaction_style() returns True; framing_hints non-empty;
   last_summarized set; no exception swallowed.
-- Obtained results:
-- Verdict:
+- Obtained results: Fixed `data/graph/behaviour_tracker.py:543` — dropped the nonexistent
+  `importance=0.8` kwarg. `test_summarize_interaction_style_direct_call` now injects
+  `store_fn = Mock(spec=store_memory, return_value={"conflicts": []})` instead of a loosely
+  mocked `Mock(return_value=None)` — a spec'd mock enforces the real signature and would have
+  caught the original `TypeError` at test time. Ran with a real `BehaviourTracker(graph,
+  store_fn=store_fn)`, drove 10 `record_query()` calls: `summarize_interaction_style()` returned
+  `True`, `framing_hints` = "prefers concise responses; often asks 'how' questions; domain
+  vocabulary: does, work, in, middleware, routing", `last_summarized` set to a real timestamp,
+  `store_fn.assert_called_once()` passed. `venv/bin/python -m pytest
+  tests/test_behaviour_tracker.py -q` — 23 passed.
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/COGNIREPO-D05.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/COGNIREPO-D05.md
@@ -70,3 +70,25 @@ small helper) before `obs.stop()`, mirroring the intended `stop_watching()` sequ
   replacement helper in `file_watcher.py` itself (e.g. `create_watcher()` returning a
   `(observer, stop_fn)` pair) rather than duplicating the flush-then-stop sequence at each
   call site.
+
+## Corrections found during implementation
+- **The initial fix (patching `_stop_observer`/`_stop` to call `_flush_and_stop_observer`) was
+  not sufficient on its own.** The backstory above already named
+  `run_watcher_with_crash_guard()` (`interface/cli/daemon.py`) as never calling `flush()`, but
+  the first pass assumed patching the `stop_fn` closures was enough without checking that
+  `run_watcher_with_crash_guard()` actually *calls* `stop_fn` on every exit path. It doesn't:
+  `except KeyboardInterrupt:` (the branch SIGTERM/Ctrl+C actually take, since the installed
+  signal handler raises `KeyboardInterrupt`) printed "stopped by user" and broke out of the loop
+  without ever calling `stop_fn(observer)` — only the crash-recovery `except Exception:` branch
+  did. This was caught by a genuine live TC-D05-1 walkthrough (real `cognirepo watch`, real
+  edit, real `SIGTERM`, direct inspection of `ast_index.json`'s per-file `sha256`) that
+  reproduced the exact data-loss bug even with the first patch applied. Fixed by also calling
+  `stop_fn(observer)` in the `KeyboardInterrupt` branch, mirroring the crash branch's
+  try/except-around-`stop_fn`. Re-ran the live walkthrough after this correction: PASS.
+- **`cognirepo verify-index` is not a valid check for "was this edit flushed."** Its DIRTY
+  detection compares source-file mtime against `manifest.json`'s `indexed_at`, which is only
+  updated by full `index-repo` runs — not by the watcher's incremental `flush()` — so it
+  reports DIRTY regardless of whether the watcher actually flushed the edit in time. TC-D05-1's
+  own "then run cognirepo verify-index" step needs to be read as "then confirm the AST index
+  reflects the edit" (e.g. via `ast_index.json`'s `sha256`/symbol list), not literally
+  `verify-index`'s exit code.

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/TEST/COGNIREPO-D05-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/TEST/COGNIREPO-D05-TEST_SUITE.md
@@ -9,15 +9,40 @@
   — was the edit indexed before shutdown?"
 - Expected results: post-shutdown, the edit is indexed (verify-index OK, not DIRTY, or the
   graph/AST index reflects the edit) — no silent event loss.
-- Obtained results: (empty — this requires a live `cognirepo watch .` process against a real
-  test repo + an actual SIGTERM/Ctrl+C; leaving for the user per skill.md §F.4.)
-- Verdict:
+- Obtained results: Executed live against `cognirepo_test_repo/easy/flask` (real
+  `cognirepo index-repo . --no-embed` foreground watcher, real SIGTERM, `debounce_ms` bumped to
+  8000 in that repo's `.cognirepo/config.json` for a comfortable manual window):
 
-Note: fix implemented and covered by an automated equivalent I could genuinely execute —
-`_flush_and_stop_observer()` added in `interface/cli/main.py`, wired into both real shutdown
-call sites (`_stop_observer` for foreground `cognirepo watch`, `_run()._stop` for the
-MCP-launched background watcher). `tests/test_watcher_debounce.py::TestShutdownFlush` queues a
-modify event with a 5s debounce window, calls `_flush_and_stop_observer(obs)` on a mock Observer
-with `_cognirepo_handler` set, and asserts `indexer.index_file`/`indexer.save` were called
-(pending event flushed) before `obs.stop()`/`obs.join()`. 7/7 passed
-(`venv/bin/python -m pytest tests/test_watcher_debounce.py -q`).
+  1. `cognirepo index-repo . --no-embed` — baseline index built (1832 symbols, 92 files).
+  2. Watcher started in background (`nohup ... &`), waited for "Watching ... Ctrl+C to stop."
+  3. Appended `def _cognirepo_tc_d05_marker(): pass` to `src/flask/helpers.py`, then
+     `kill -TERM <pid>` ~1s later (well inside the 8s debounce window). Log showed
+     `[watcher:...] stopped by user.` / `[watcher] stopped.`.
+  4. **First run (before this fix): FAILED.** Inspecting `.cognirepo/index/ast_index.json`
+     directly showed the entry's `sha256`/`indexed_at` unchanged from the pre-edit baseline and
+     the new symbol absent — the edit was silently dropped exactly as D05 describes, even with
+     `_stop_observer`/`_run()._stop` already patched to flush. Root-caused to
+     `run_watcher_with_crash_guard()`'s `except KeyboardInterrupt` branch never calling
+     `stop_fn(observer)` at all (only the crash/`except Exception` branch did) — SIGTERM's
+     installed handler raises `KeyboardInterrupt`, so the primary real-world shutdown path
+     bypassed the flush entirely. Fixed in `interface/cli/daemon.py` (see COGNIREPO-D05 commit
+     history) — added the missing `stop_fn(observer)` call to the `KeyboardInterrupt` branch.
+  5. **Second run (after this fix): PASSED.** Reverted the test edit, rebuilt the baseline
+     index, repeated steps 1–3 identically. `ast_index.json`'s recorded `sha256` for
+     `src/flask/helpers.py` now matches the post-edit file content
+     (`fd81ac1e318baa54127ca9df9a00d5ca36b61716494cf0199257758feefc620a`) and the new
+     `_cognirepo_tc_d05_marker` symbol is present in the index — the edit was flushed before
+     the process exited.
+  6. Note: `cognirepo verify-index` is NOT the right check here — its DIRTY detection compares
+     file mtime against `manifest.json`'s `indexed_at` (set only by full `index-repo` runs, not
+     by watcher flushes), so it reports DIRTY regardless of whether the watcher's incremental
+     flush actually ran. Verified directly against `ast_index.json`'s per-file `sha256` instead.
+  7. Cleaned up: reverted the test edit in the flask test repo (`git checkout --
+     src/flask/helpers.py`); `.cognirepo/` there is gitignored/untracked, nothing to revert.
+- Verdict: PASS (after the `run_watcher_with_crash_guard` KeyboardInterrupt fix — see step 4/5)
+
+Also covered by an automated regression: `tests/test_cli_daemon.py::TestRunWatcherWithCrashGuardKeyboardInterrupt`
+asserts `stop_fn(observer)` is called when the sleep loop is interrupted by `KeyboardInterrupt`,
+and that a broken `stop_fn` doesn't crash the shutdown path. Plus the existing
+`tests/test_watcher_debounce.py::TestShutdownFlush` covering `_flush_and_stop_observer()` itself.
+4/4 and 7/7 passed respectively.

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/TEST/COGNIREPO-D05-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/TEST/COGNIREPO-D05-TEST_SUITE.md
@@ -9,5 +9,15 @@
   — was the edit indexed before shutdown?"
 - Expected results: post-shutdown, the edit is indexed (verify-index OK, not DIRTY, or the
   graph/AST index reflects the edit) — no silent event loss.
-- Obtained results:
+- Obtained results: (empty — this requires a live `cognirepo watch .` process against a real
+  test repo + an actual SIGTERM/Ctrl+C; leaving for the user per skill.md §F.4.)
 - Verdict:
+
+Note: fix implemented and covered by an automated equivalent I could genuinely execute —
+`_flush_and_stop_observer()` added in `interface/cli/main.py`, wired into both real shutdown
+call sites (`_stop_observer` for foreground `cognirepo watch`, `_run()._stop` for the
+MCP-launched background watcher). `tests/test_watcher_debounce.py::TestShutdownFlush` queues a
+modify event with a 5s debounce window, calls `_flush_and_stop_observer(obs)` on a mock Observer
+with `_cognirepo_handler` set, and asserts `indexer.index_file`/`indexer.save` were called
+(pending event flushed) before `obs.stop()`/`obs.join()`. 7/7 passed
+(`venv/bin/python -m pytest tests/test_watcher_debounce.py -q`).

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D06/TEST/COGNIREPO-D06-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D06/TEST/COGNIREPO-D06-TEST_SUITE.md
@@ -10,8 +10,17 @@
   write the way it did before the refactor?"
 - Expected results: write is still blocked/raises exactly as before the fix — no silent
   behavior change.
-- Obtained results:
-- Verdict:
+- Obtained results: Ran a real end-to-end script (isolated `.cognirepo` fixture, faiss backend)
+  using `SemanticMemory()` (the actual production wiring, which now passes
+  `breaker_factory=get_breaker, cleanup_queue_factory=CleanupQueue` into `get_vector_adapter()`
+  per the D06 fix). Tripped the breaker via `get_breaker().record_failure()`, then called
+  `db.save()`: raised `CircuitOpenError("[CircuitBreaker:cognirepo] OPEN — retry in 30s")` —
+  identical to pre-refactor behavior. `venv/bin/python -m pytest tests/test_storage_adapter.py -q`
+  — 19/20 passed (1 pre-existing unrelated failure,
+  `test_default_returns_local_vector_db`, confirmed present on HEAD before this branch too —
+  caused by a real `~/.cognirepo` chroma store on this machine interfering with the
+  `_find_config` monkeypatch, unrelated to D06).
+- Verdict: PASS
 
 ## TC-D06-2: Suppressed rows still enqueue for cleanup
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy/flask
@@ -21,5 +30,9 @@
 - Prompt: "Store a duplicate-ish memory that gets auto-suppressed — does it still show up in
   the cleanup queue for deferred deletion?"
 - Expected results: suppressed row is still enqueued in `CleanupQueue` exactly as before.
-- Obtained results:
-- Verdict:
+- Obtained results: Same script/session as TC-D06-1. Stored a memory via `db.add(vec,
+  "duplicate-ish memory text", importance=0.6, source="memory")`, recorded `len(CleanupQueue())`
+  before (0), then called `db.suppress_row(0, reason="auto_superseded", similarity=0.93)` and
+  re-checked the queue length (1) — the suppressed row was enqueued via the injected
+  `cleanup_queue_factory=CleanupQueue`, exactly matching pre-refactor behavior.
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/COGNIREPO-D07.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/COGNIREPO-D07.md
@@ -1,0 +1,61 @@
+# COGNIREPO-D07 — HybridRetriever discards real stored source, hardcodes "semantic"
+
+Epic: COGNIREPO-100 · Branch: defect/COGNIREPO-D04_D05_D06 (bundled per user direction) · Base: story/COGNIREPO-105
+
+## Backstory
+Found while re-verifying TC-105-1 (`COGNIREPO-105` manual test suite) after fixing
+`COGNIREPO-D04`. Even with D04's `store_memory()` kwarg fix applied, a real end-to-end run —
+`BehaviourTracker.summarize_interaction_style()` → `store_memory(summary,
+source="interaction_style")` → `retrieve_memory('interaction style')` — never returned
+`source="interaction_style"`. The memory *was* stored correctly (confirmed via a fresh isolated
+`.cognirepo/`, no docs ingested); `retrieve_memory` returned it, but labeled
+`source: "semantic"`.
+
+Root cause: `HybridRetriever._vector_retrieve()` (`intelligence/retrieval/hybrid.py:182`, pre-fix)
+hardcoded `"source": "semantic"` on every vector-backend hit, discarding whatever the real
+`source` metadata field was on the stored record (`memory`, `interaction_style`, `symbol`
+(AST-embedded symbols, `ast_indexer.py:1562`/`:1855`), `init_doc` (doc chunks,
+`doc_ingester.py:142`), `auto_discovery`, …) — `core/vector_db/local_vector_db.py`'s
+`search_with_scores()` already returns the real field (`entry = dict(record)`), so the
+information was available and simply thrown away one layer up.
+
+`interface/tools/retrieve_memory.py::_structure_results()` (line 103, pre-fix) worked around
+the missing real source with a text-shape heuristic — `source == "semantic" and " in " in text
+and ":" in text` — to approximate "this vector hit looks like an AST symbol entry" for
+code_hits/doc_hits bucketing, since it never had access to the real `source == "symbol"` value.
+
+This is a pre-existing bug (not introduced by COGNIREPO-105) that happened to block TC-105-1's
+verification: it makes it structurally impossible for `retrieve_memory()` to ever report a
+vector hit's true storage `source`, for any caller, not just interaction-style memories.
+
+## Description
+1. `intelligence/retrieval/hybrid.py::_vector_retrieve()` — preserve the real
+   `record.get("source", "memory")` instead of hardcoding `"semantic"`.
+2. `interface/tools/retrieve_memory.py::_structure_results()` — replace the
+   `source == "semantic" and <text-shape heuristic>` approximation with the precise
+   `source in ("ast", "symbol")` check now that the real value is available. Drop the now-dead
+   text-shape sub-condition (it existed only to guess at "symbol" without the real field).
+3. `interface/tools/context_pack.py` was already keying its code/doc bucketing off
+   `source == "ast"` specifically (not `"semantic"`), so it is unaffected by this fix — no
+   changes needed there, confirmed by re-running `tests/test_context_pack.py`.
+
+## Acceptance criteria
+1. `retrieve_memory('interaction style')` returns `source="interaction_style"` for a memory
+   stored via `store_memory(summary, source="interaction_style")` — this is what unblocks
+   TC-105-1.
+2. `retrieve_memory(structured=True)` still buckets AST/symbol hits into `code_hits` and
+   everything else into `doc_hits` exactly as before (regression tests using real `source="ast"`
+   and `source="symbol"` hits, plus non-code hits that happen to contain "X in Y:Z"-shaped text
+   and must NOT be miscategorized as code hits).
+3. `tests/test_context_pack.py`, `tests/test_retrieve_memory_extended.py`, and the full suite
+   stay green.
+
+## Risks / notes
+- Widest-blast-radius fix in this bundle: `_vector_retrieve()` and `_structure_results()` are on
+  the path of every `retrieve_memory`/`context_pack` call. Reviewed all current callers of
+  `source` on hybrid-retrieve results (`context_pack.py`, `retrieve_memory.py`,
+  `semantic_search_code.py` — the latter reads its own dedicated AST index directly, bypassing
+  `HybridRetriever` entirely, so unaffected) before landing this.
+- Filed and fixed in the same pass per explicit user direction (see `COGNIREPO-105`'s
+  `TEST/COGNIREPO-105-TEST_SUITE.md` re-verification note) — bundled into
+  `defect/COGNIREPO-D04_D05_D06` rather than its own branch/PR.

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/TEST/COGNIREPO-D07-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/TEST/COGNIREPO-D07-TEST_SUITE.md
@@ -11,8 +11,17 @@
 - Expected results: retrieve_memory() returns the hit with source="interaction_style" (not
   "semantic"); structured=True still buckets AST/symbol hits into code_hits and everything
   else into doc_hits.
-- Obtained results:
-- Verdict:
+- Obtained results: Fixed `intelligence/retrieval/hybrid.py::_vector_retrieve()` to report
+  `r.get("source", "memory")` instead of hardcoded `"semantic"`. Added
+  `tests/test_hybrid_retrieval.py::TestVectorRetrieveSourcePreservation` — stored a vector
+  directly with `source="interaction_style"` via `r.db.add(...)`, called
+  `r._vector_retrieve(vec, k=5)`, confirmed `results[0]["source"] == "interaction_style"`; a
+  companion test confirms a plain `SemanticMemory().store(text)` (no explicit source) still
+  reports `source == "memory"`. Combined with the D08 fix, the full TC-105-1 round trip
+  (`store_memory(summary, source="interaction_style")` → `retrieve_memory('interaction
+  style')`) now returns `source="interaction_style"` — verified via a real isolated-`.cognirepo`
+  script, not mocks. `venv/bin/python -m pytest tests/test_hybrid_retrieval.py -q` — 8 passed.
+- Verdict: PASS
 
 ## TC-D07-2: code_hits/doc_hits bucketing unaffected for non-AST text shapes
 - Test repo: /home/ashlesh/my_works/cognirepo
@@ -23,5 +32,17 @@
 - Expected results: all existing context_pack / retrieve_memory tests stay green — no
   regression in code_hits/doc_hits classification for real "ast"/"symbol" hits or for
   doc/memory hits whose text happens to contain "X in Y:Z"-shaped substrings.
-- Obtained results:
-- Verdict:
+- Obtained results: Updated `interface/tools/retrieve_memory.py::_structure_results()` to
+  classify via `source in ("ast", "symbol")` instead of the previous
+  `source == "semantic" and <text-shape heuristic>`. Added
+  `test_structure_results_symbol_source_is_code_hit` (a real `source="symbol"` AST hit lands in
+  `code_hits` with correct file/line extraction) and
+  `test_structure_results_non_ast_source_with_in_colon_shape_stays_doc_hit` (a real
+  `source="interaction_style"` hit whose text happens to contain "X in Y:Z"-shaped substrings
+  correctly stays in `doc_hits`, not miscategorized). `context_pack.py` was already keying its
+  own code/doc bucketing off `source == "ast"` specifically (never `"semantic"`), confirmed
+  unaffected. `venv/bin/python -m pytest tests/test_context_pack.py
+  tests/test_retrieve_memory_extended.py -q` — 35 passed. Full suite:
+  `venv/bin/python -m pytest tests/ -q` — 1249 passed, 5 skipped (baseline was 1227 before this
+  branch).
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/TEST/COGNIREPO-D07-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/TEST/COGNIREPO-D07-TEST_SUITE.md
@@ -1,0 +1,27 @@
+# COGNIREPO-D07 — Manual test suite
+
+## TC-D07-1: retrieve_memory preserves real stored source
+- Test repo: /home/ashlesh/my_works/cognirepo (this repo, isolated .cognirepo test fixture)
+- Prerequisites: fix applied (hybrid.py preserves real source; retrieve_memory.py's
+  _structure_results uses source in ("ast", "symbol")).
+- What to do: store a memory with a real store_memory(text, source="interaction_style") call,
+  then retrieve_memory() it and inspect the returned source field.
+- Prompt: n/a — automated via tests/test_hybrid_retrieval_extended.py and
+  tests/test_retrieve_memory_extended.py (direct call, no mock of the source field).
+- Expected results: retrieve_memory() returns the hit with source="interaction_style" (not
+  "semantic"); structured=True still buckets AST/symbol hits into code_hits and everything
+  else into doc_hits.
+- Obtained results:
+- Verdict:
+
+## TC-D07-2: code_hits/doc_hits bucketing unaffected for non-AST text shapes
+- Test repo: /home/ashlesh/my_works/cognirepo
+- Prerequisites: fix applied.
+- What to do: run the full pytest suite, focusing on tests/test_context_pack.py and
+  tests/test_retrieve_memory_extended.py.
+- Prompt: n/a — automated.
+- Expected results: all existing context_pack / retrieve_memory tests stay green — no
+  regression in code_hits/doc_hits classification for real "ast"/"symbol" hits or for
+  doc/memory hits whose text happens to contain "X in Y:Z"-shaped substrings.
+- Obtained results:
+- Verdict:

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/COGNIREPO-D08.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/COGNIREPO-D08.md
@@ -1,0 +1,53 @@
+# COGNIREPO-D08 — store_memory()'s `source` argument is silently discarded
+
+Epic: COGNIREPO-100 · Branch: defect/COGNIREPO-D04_D05_D06 (bundled per user direction) · Base: story/COGNIREPO-105
+
+## Backstory
+Found while re-verifying TC-105-1 after fixing `COGNIREPO-D04` (kwarg mismatch) and
+`COGNIREPO-D07` (hybrid.py hardcoding `source="semantic"`). Even with both fixes applied, a
+real end-to-end run still failed: `store_memory(summary, source="interaction_style")` followed
+by `retrieve_memory('interaction style')` returned the memory with `source: "memory"`, not
+`"interaction_style"`.
+
+Root cause: `interface/tools/store_memory.py`'s `store_memory(text, source="")` accepts a
+`source` parameter and uses it for the `log_event()` metadata and the returned status dict, but
+never forwards it to the actual storage call:
+
+```python
+mem.store(text)   # <- source is dropped here
+```
+
+`data/memory/semantic_memory.py::SemanticMemory.store(self, text)` never accepted a `source`
+parameter at all — it always called `self.db.add(vector, text, importance)`, which defaults to
+`source="memory"` in `LocalVectorDB.add()`. So every memory ever stored through the public
+`store_memory()` tool — regardless of what `source=` the caller passed — was persisted with
+`source="memory"`.
+
+This is a third, independent pre-existing bug in the same `store_memory` → `retrieve_memory`
+round trip that TC-105-1 exercises (alongside D04 and D07) — not introduced by COGNIREPO-105.
+
+## Description
+1. `data/memory/semantic_memory.py::SemanticMemory.store()` — accept `source: str = "memory"`
+   (matching `LocalVectorDB.add()`'s existing default) and forward it to `self.db.add(...,
+   source=source)`.
+2. `interface/tools/store_memory.py` — change `mem.store(text)` to
+   `mem.store(text, source=source or "memory")`. The `or "memory"` preserves the existing
+   behavior for every caller that passes `source=""` (the CLI default, `--source ""`) — only
+   callers that pass a real, truthy source (e.g. `source="interaction_style"`,
+   `source="benchmark"`, `source="session_seed"`) now actually get it persisted.
+
+## Acceptance criteria
+1. `store_memory(text, source="interaction_style")` followed by
+   `retrieve_memory('interaction style')` returns a hit with `source="interaction_style"` — this
+   is what fully unblocks TC-105-1 (together with D04 and D07).
+2. `store_memory(text)` (no source, or `source=""`) still stores with `source="memory"` —
+   no behavior change for the common case.
+3. Existing `store_memory`/`SemanticMemory` tests stay green; new regression tests cover both
+   the "real source forwarded" and "empty source defaults to memory" cases.
+
+## Risks / notes
+- Narrowly scoped, single call-site fix with a backward-compatible default — low blast radius
+  compared to D07.
+- Filed and fixed in the same pass per explicit user direction (see `COGNIREPO-105`'s
+  `TEST/COGNIREPO-105-TEST_SUITE.md` re-verification note) — bundled into
+  `defect/COGNIREPO-D04_D05_D06` rather than its own branch/PR.

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/TEST/COGNIREPO-D08-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/TEST/COGNIREPO-D08-TEST_SUITE.md
@@ -7,8 +7,18 @@
   retrieve_memory(text) and inspect the source field.
 - Prompt: n/a — automated via tests/test_store_memory*.py and tests/test_memory.py.
 - Expected results: retrieve_memory() returns the hit with source="interaction_style".
-- Obtained results:
-- Verdict:
+- Obtained results: `SemanticMemory.store()` now accepts `source: str = "memory"` and forwards
+  it to `self.db.add(..., source=source)`; `store_memory()` now calls `mem.store(text, source=source
+  or "memory")`. Added `TestSemanticMemory.test_store_forwards_real_source` (direct
+  `SemanticMemory` layer) and `TestStoreMemoryToolSourceForwarding.test_real_source_is_persisted`
+  (full `store_memory()` tool call, unmocked) in `tests/test_memory.py` — both confirm
+  `sm.retrieve(text, top_k=1)[0]["source"]` matches the real source passed in. Also
+  end-to-end confirmed via the same isolated-`.cognirepo` script used for TC-D07-1: the full
+  `BehaviourTracker.summarize_interaction_style()` → `store_memory(..., source=
+  "interaction_style")` → `retrieve_memory('interaction style')` round trip now returns
+  `source="interaction_style"` (previously "memory" even after D04/D07). `venv/bin/python -m
+  pytest tests/test_memory.py -q` — 16 passed.
+- Verdict: PASS
 
 ## TC-D08-2: default/empty source still stores as "memory"
 - Test repo: /home/ashlesh/my_works/cognirepo
@@ -18,5 +28,9 @@
 - Prompt: n/a — automated.
 - Expected results: stored source is "memory" (unchanged from pre-fix behavior) — no
   regression for the common no-source-specified case.
-- Obtained results:
-- Verdict:
+- Obtained results: `test_store_default_source_is_memory` (SemanticMemory layer) and
+  `test_empty_source_still_defaults_to_memory` (store_memory() tool layer) in
+  `tests/test_memory.py` both confirm `source == "memory"` when no source (or `source=""`) is
+  passed — the `source or "memory"` forwarding in `store_memory.py` preserves the pre-fix
+  default for the common case.
+- Verdict: PASS

--- a/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/TEST/COGNIREPO-D08-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/TEST/COGNIREPO-D08-TEST_SUITE.md
@@ -1,0 +1,22 @@
+# COGNIREPO-D08 — Manual test suite
+
+## TC-D08-1: store_memory forwards a real source to storage
+- Test repo: /home/ashlesh/my_works/cognirepo (this repo, isolated .cognirepo test fixture)
+- Prerequisites: fix applied (SemanticMemory.store() accepts source; store_memory() forwards it).
+- What to do: call store_memory(text, source="interaction_style") directly, then
+  retrieve_memory(text) and inspect the source field.
+- Prompt: n/a — automated via tests/test_store_memory*.py and tests/test_memory.py.
+- Expected results: retrieve_memory() returns the hit with source="interaction_style".
+- Obtained results:
+- Verdict:
+
+## TC-D08-2: default/empty source still stores as "memory"
+- Test repo: /home/ashlesh/my_works/cognirepo
+- Prerequisites: fix applied.
+- What to do: call store_memory(text) with no source argument, then inspect the stored
+  metadata's source field.
+- Prompt: n/a — automated.
+- Expected results: stored source is "memory" (unchanged from pre-fix behavior) — no
+  regression for the common no-source-specified case.
+- Obtained results:
+- Verdict:

--- a/JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-105/TEST/COGNIREPO-105-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-105/TEST/COGNIREPO-105-TEST_SUITE.md
@@ -9,7 +9,64 @@
 - Expected results: a source="interaction_style" memory exists — proving the injected store_fn
   path works end-to-end (previously the lazy upward import).
 - Obtained results:
-- Verdict:
+Setup: Ran 10 diverse retrieve_memory queries against cognirepo-ansible (module_utils imports, executor internals, deprecation API, changelog conventions, inventory parsing, integration test targets, architecture overview, sanity config, TaskExecutor callers, AnsibleModule validation) to push past the _STYLE_SUMMARIZE_EVERY threshold.
+
+Prompt executed: retrieve_memory('interaction style')
+
+Obtained results:
+5 hits returned, ALL source="semantic":
+1. "get_user_profile() ... Call at session start" (docs)
+2. "get_user_profile() ... calibrate response style" (docs)
+3. "User behavior profiling ... CogniRepo tracks how you interact..." (docs)
+4. "Claude Code Behaviour Hooks ... behaviour_hook.py ... sync_claude_memory.py" (docs)
+5. "Code of Conduct scope..." (unrelated doc noise)
+No result carried source="interaction_style".
+
+Cross-check via get_user_profile():
+total_queries_tracked: 35   (well above any reasonable threshold)
+sample_queries includes "interaction style" (the query itself, tracked)
+depth_preference: "detailed", code_focus_percent: 100, etc. — profile IS being computed
+- Verdict: FAIL :
+
+The behavior-tracking side works — get_user_profile() correctly aggregates 35 tracked queries into a live profile (depth preference, terminology, question-type distribution). But summarize_interaction_style() is not persisting that profile into the memory/vector store: retrieve_memory('interaction style') returns zero hits with source="interaction_style", only pre-existing documentation chunks that happen to mention the term.
+
+This means the injected store_fn path is not confirmed end-to-end. Two possible root causes, given the framing of your test ("previously the lazy upward import"):
+1. summarize_interaction_style() never actually calls store_fn(...) (threshold logic not firing despite 35 tracked queries).
+2. It calls store_fn but the memory is stored with a different source label or into a different repo scope/index than the one retrieve_memory searches.
+
+Suggested next step: grep the CogniRepo source for summarize_interaction_style and _STYLE_SUMMARIZE_EVERY in .cognirepo/ or the installed package to check (a) whether the threshold is actually being evaluated on this counter, and (b) what source= string it passes to store_fn/store_memory.
+
+### Re-verification (defect/COGNIREPO-D04_D05_D06 branch)
+
+Root-caused to three independent bugs, each filed and fixed:
+- **COGNIREPO-D04** — `summarize_interaction_style()` called `store_fn(summary,
+  source="interaction_style", importance=0.8)`, but `store_memory()` has no `importance`
+  kwarg → `TypeError`, swallowed by a blanket `except Exception`. Fixed by dropping the kwarg.
+- **COGNIREPO-D07** — even with D04 fixed, `HybridRetriever._vector_retrieve()` hardcoded
+  `"source": "semantic"` on every vector hit, discarding the real stored source. Fixed to
+  preserve the real value.
+- **COGNIREPO-D08** — even with D04+D07 fixed, `store_memory()`'s `source` argument was never
+  forwarded to `SemanticMemory.store()`, which always persisted with the default `source=
+  "memory"`. Fixed by threading `source` through both.
+
+Re-ran the exact scenario (isolated `.cognirepo` fixture, real `BehaviourTracker(store_fn=
+store_memory)`, 10 diverse queries to cross `_STYLE_SUMMARIZE_EVERY`, then
+`retrieve_memory('interaction style')`):
+
+```
+Total hits: 1
+interaction_style-sourced hits: 1
+ - User interaction style: prefers concise answers. Most common question type: how.
+   Common terminology: does, work, what, explain, module_utils. Recent query examples:
+   explain sanity config | who calls TaskExecutor | how does AnsibleModule validation
+   work. | source= interaction_style
+TC-105-1: PASS
+```
+
+Full suite green throughout: `venv/bin/python -m pytest tests/ -q` — 1249 passed, 5 skipped
+(baseline before this branch: 1227 passed, 5 skipped).
+
+- Verdict (re-verified): **PASS**
 
 ## TC-105-2: Guard self-test
 - Test repo: /home/ashlesh/my_works/cognirepo
@@ -32,3 +89,8 @@
   what this case tests. Also covered as an automated self-test:
   `tests/test_check_circular_deps.py::test_fails_on_deliberately_added_lazy_upward_import`.
 - Verdict: PASS (detection behavior confirmed; see note on the pre-existing D06 exception)
+
+**Update:** `COGNIREPO-D06` (the `core/vector_db/local_vector_db.py:167,265` core→data
+violations referenced above) is now resolved on `defect/COGNIREPO-D04_D05_D06` — HEAD reports
+zero layer violations (`scripts/check_circular_deps.py restructure/import-graph.json
+--verbose`), not the two deferred ones.

--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -25,7 +25,7 @@ stories:
     status: in-review
     branch: story/COGNIREPO-105
     pr: https://github.com/ashlesh-t/cognirepo/pull/39
-    test_status: pass
+    test_status: pass  # TC-105-1 originally FAILed; re-verified pass via defect/COGNIREPO-D04_D05_D06 (see its TEST_SUITE.md)
   - id: COGNIREPO-106
     status: not-started
     branch: story/COGNIREPO-106
@@ -48,18 +48,28 @@ defects:
     pr: https://github.com/ashlesh-t/cognirepo/pull/33
     test_status: pass
   - id: COGNIREPO-D04
-    status: not-started
-    branch: defect/COGNIREPO-D04
-    pr: null
-    test_status: not-run
+    status: in-review
+    branch: defect/COGNIREPO-D04_D05_D06
+    pr: https://github.com/ashlesh-t/cognirepo/pull/40
+    test_status: pass
   - id: COGNIREPO-D05
-    status: not-started
-    branch: defect/COGNIREPO-D05
-    pr: null
-    test_status: not-run
+    status: in-review
+    branch: defect/COGNIREPO-D04_D05_D06
+    pr: https://github.com/ashlesh-t/cognirepo/pull/40
+    test_status: pass
   - id: COGNIREPO-D06
-    status: not-started
-    branch: defect/COGNIREPO-D06
-    pr: null
-    test_status: not-run
+    status: in-review
+    branch: defect/COGNIREPO-D04_D05_D06
+    pr: https://github.com/ashlesh-t/cognirepo/pull/40
+    test_status: pass
+  - id: COGNIREPO-D07
+    status: in-review
+    branch: defect/COGNIREPO-D04_D05_D06
+    pr: https://github.com/ashlesh-t/cognirepo/pull/40
+    test_status: pass
+  - id: COGNIREPO-D08
+    status: in-review
+    branch: defect/COGNIREPO-D04_D05_D06
+    pr: https://github.com/ashlesh-t/cognirepo/pull/40
+    test_status: pass
 epic_test_suite_status: not-run

--- a/core/vector_db/factory.py
+++ b/core/vector_db/factory.py
@@ -68,8 +68,18 @@ def _heal_crashed_chroma(path: Path) -> None:
     quarantine_chroma_store(path)
 
 
-def get_vector_adapter(dim: int = 384) -> VectorStorageAdapter:
-    """Return FAISS or ChromaDB adapter based on config.json storage.vector_backend."""
+def get_vector_adapter(
+    dim: int = 384,
+    *,
+    breaker_factory=None,
+    cleanup_queue_factory=None,
+) -> VectorStorageAdapter:
+    """Return FAISS or ChromaDB adapter based on config.json storage.vector_backend.
+
+    breaker_factory / cleanup_queue_factory — forwarded to LocalVectorDB only
+    (the faiss backend); ChromaDBAdapter has no circuit-breaker/cleanup-queue
+    integration. See COGNIREPO-D06.
+    """
     backend = _read_backend()
     if backend == "chroma":
         try:
@@ -96,7 +106,11 @@ def get_vector_adapter(dim: int = 384) -> VectorStorageAdapter:
             )
     _log.debug("vector backend: faiss")
     from core.vector_db.local_vector_db import LocalVectorDB  # pylint: disable=import-outside-toplevel
-    return LocalVectorDB(dim=dim)
+    return LocalVectorDB(
+        dim=dim,
+        breaker_factory=breaker_factory,
+        cleanup_queue_factory=cleanup_queue_factory,
+    )
 
 
 def _read_backend() -> str:

--- a/core/vector_db/local_vector_db.py
+++ b/core/vector_db/local_vector_db.py
@@ -36,12 +36,21 @@ class LocalVectorDB(VectorStorageAdapter):
     Local vector database using FAISS for storing and searching semantic embeddings.
     """
 
-    def __init__(self, dim=384):
+    def __init__(self, dim=384, *, breaker_factory=None, cleanup_queue_factory=None):
         """
         Initializes the LocalVectorDB with the specified dimensionality.
+
+        breaker_factory / cleanup_queue_factory — optional zero-arg callables
+        supplied by the caller (e.g. get_vector_adapter()) that return a
+        circuit breaker / CleanupQueue instance. Keeps this core-layer module
+        free of upward `core → data` imports (COGNIREPO-D06) — callers in
+        data/intelligence/interface wire in data.memory.circuit_breaker.get_breaker
+        and data.memory.cleanup_queue.CleanupQueue.
         """
         import logging  # pylint: disable=import-outside-toplevel
         self.dim = dim
+        self._breaker_factory = breaker_factory
+        self._cleanup_queue_factory = cleanup_queue_factory
         if os.path.exists(_index_file()):
             try:
                 self.index = faiss.read_index(_index_file())
@@ -164,14 +173,15 @@ class LocalVectorDB(VectorStorageAdapter):
         (e.g. Claude + Gemini both calling store_memory at the same time)
         do not corrupt the FAISS binary or metadata JSON.
         """
-        from data.memory.circuit_breaker import get_breaker  # pylint: disable=import-outside-toplevel
-        breaker = get_breaker()
-        breaker.check()
+        breaker = self._breaker_factory() if self._breaker_factory is not None else None
+        if breaker is not None:
+            breaker.check()
         with store_lock():
             faiss.write_index(self.index, _index_file())
             self._save_meta()
         self._loaded_disk_mtime = self._disk_mtime()
-        breaker.record_success()
+        if breaker is not None:
+            breaker.record_success()
 
     def add(self, vector, text, importance, source: str = "memory", behaviour_score: float = 0.0):
         """
@@ -261,17 +271,17 @@ class LocalVectorDB(VectorStorageAdapter):
         entry["suppressed_at"] = _now_iso()
         self._save_meta()
         # Enqueue for priority-queue cleanup
-        try:
-            from data.memory.cleanup_queue import CleanupQueue  # pylint: disable=import-outside-toplevel
-            CleanupQueue().push(
-                entry_id=faiss_row,
-                store="semantic",
-                importance=float(entry.get("importance", 0.5)),
-                suppressed_at=entry["suppressed_at"],
-                similarity_score=float(similarity),
-            )
-        except Exception:  # pylint: disable=broad-except
-            pass  # queue is best-effort
+        if self._cleanup_queue_factory is not None:
+            try:
+                self._cleanup_queue_factory().push(
+                    entry_id=faiss_row,
+                    store="semantic",
+                    importance=float(entry.get("importance", 0.5)),
+                    suppressed_at=entry["suppressed_at"],
+                    similarity_score=float(similarity),
+                )
+            except Exception:  # pylint: disable=broad-except
+                pass  # queue is best-effort
         return True
 
     def search(self, vector, top_k=5, source: str | None = None):

--- a/data/graph/behaviour_tracker.py
+++ b/data/graph/behaviour_tracker.py
@@ -514,7 +514,8 @@ class BehaviourTracker:
         """
         When query_patterns buffer reaches _STYLE_SUMMARIZE_EVERY entries,
         build a natural-language summary and store it as a semantic memory
-        with importance=0.8 and source="interaction_style".
+        with source="interaction_style" (importance is computed internally by
+        store_memory() via SemanticMemory.compute_importance()).
 
         Returns True if a memory was stored, False otherwise.
         """
@@ -540,7 +541,7 @@ class BehaviourTracker:
                 f"Common terminology: {', '.join(top_terms) if top_terms else 'N/A'}. "
                 f"Recent query examples: {' | '.join(q[:80] for q in sample_queries)}."
             )
-            self._store_fn(summary, source="interaction_style", importance=0.8)
+            self._store_fn(summary, source="interaction_style")
             # Build framing hints snapshot for get_user_profile()
             hints_parts = []
             if depth != "unknown":

--- a/data/memory/auto_store.py
+++ b/data/memory/auto_store.py
@@ -100,13 +100,15 @@ class AutoStore:
 
         try:
             from data.memory.embeddings import encode_with_timeout  # pylint: disable=import-outside-toplevel
+            from data.memory.circuit_breaker import get_breaker  # pylint: disable=import-outside-toplevel
+            from data.memory.cleanup_queue import CleanupQueue  # pylint: disable=import-outside-toplevel
             from core.vector_db.local_vector_db import LocalVectorDB  # pylint: disable=import-outside-toplevel
         except ImportError as exc:
             log.debug("AutoStore: cannot import deps: %s", exc)
             return False
 
         from data.memory.embeddings import encode_with_timeout  # pylint: disable=import-outside-toplevel
-        db = LocalVectorDB()
+        db = LocalVectorDB(breaker_factory=get_breaker, cleanup_queue_factory=CleanupQueue)
 
         vec = encode_with_timeout(text).astype("float32")
 

--- a/data/memory/semantic_memory.py
+++ b/data/memory/semantic_memory.py
@@ -47,7 +47,7 @@ class SemanticMemory:
 
         return min(length_score + keyword_score, 1)
 
-    def store(self, text):
+    def store(self, text, source: str = "memory"):
         """
         Store a text memory with its calculated importance.
         """
@@ -55,7 +55,7 @@ class SemanticMemory:
 
         importance = self.compute_importance(text)
 
-        self.db.add(vector, text, importance)
+        self.db.add(vector, text, importance, source=source)
 
         logger.debug("Stored semantic memory with importance: %s", importance)
 

--- a/data/memory/semantic_memory.py
+++ b/data/memory/semantic_memory.py
@@ -10,6 +10,8 @@ Module for managing and retrieving semantic memories using vector embeddings.
 import logging
 
 from core.vector_db.factory import get_vector_adapter
+from data.memory.circuit_breaker import get_breaker
+from data.memory.cleanup_queue import CleanupQueue
 from data.memory.embeddings import encode_with_timeout
 
 logger = logging.getLogger(__name__)
@@ -23,7 +25,11 @@ class SemanticMemory:
         """
         Initialize the vector database.
         """
-        self.db = get_vector_adapter(dim=384)
+        self.db = get_vector_adapter(
+            dim=384,
+            breaker_factory=get_breaker,
+            cleanup_queue_factory=CleanupQueue,
+        )
 
     def compute_importance(self, text):
         """

--- a/intelligence/indexer/doc_ingester.py
+++ b/intelligence/indexer/doc_ingester.py
@@ -100,13 +100,15 @@ class DocIngester:
 
         try:
             from data.memory.embeddings import get_model          # pylint: disable=import-outside-toplevel
+            from data.memory.circuit_breaker import get_breaker    # pylint: disable=import-outside-toplevel
+            from data.memory.cleanup_queue import CleanupQueue     # pylint: disable=import-outside-toplevel
             from core.vector_db.factory import get_vector_adapter  # pylint: disable=import-outside-toplevel
         except ImportError as exc:
             log.warning("DocIngester: cannot import dependencies (%s) — skipping", exc)
             return {"chunks": 0, "files": 0}
 
         model = get_model()
-        db = get_vector_adapter()
+        db = get_vector_adapter(breaker_factory=get_breaker, cleanup_queue_factory=CleanupQueue)
 
         # Cap total chunks to avoid OOM on very large repos
         if len(chunks) > _MAX_TOTAL_CHUNKS:

--- a/intelligence/retrieval/hybrid.py
+++ b/intelligence/retrieval/hybrid.py
@@ -179,7 +179,11 @@ class HybridRetriever:  # pylint: disable=too-few-public-methods
             results.append({
                 "text": r.get("text", ""),
                 "importance": r.get("importance", 0.5),
-                "source": "semantic",
+                # COGNIREPO-D07: preserve the real stored metadata source
+                # (e.g. "memory", "interaction_style", "symbol", "init_doc")
+                # instead of the previous hardcoded "semantic" label, which
+                # discarded it for every vector-backend hit.
+                "source": r.get("source", "memory"),
                 "vector_score": max(0.0, 1.0 - dist / 2.0),
                 "_id": r.get("text", ""),  # dedup key
             })

--- a/interface/cli/daemon.py
+++ b/interface/cli/daemon.py
@@ -215,6 +215,15 @@ def run_watcher_with_crash_guard(
             break  # clean exit — don't restart
         except KeyboardInterrupt:
             print(f"[watcher:{session_id}] stopped by user.", flush=True)
+            # COGNIREPO-D05: this is the primary real-world shutdown path
+            # (Ctrl+C / SIGTERM both raise KeyboardInterrupt here) — without
+            # calling stop_fn(), _flush_and_stop_observer()'s flush() never
+            # runs and any debounced-but-unflushed edit is silently dropped.
+            if observer is not None:
+                try:
+                    stop_fn(observer)
+                except Exception:  # pylint: disable=broad-except
+                    pass
             break
         except Exception as exc:  # pylint: disable=broad-except
             print(

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -42,6 +42,20 @@ from core.config.paths import get_path
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
+def _flush_and_stop_observer(obs) -> None:
+    """Flush any pending debounced watcher events, then stop/join the observer.
+
+    COGNIREPO-D05: create_watcher() sets observer._cognirepo_handler so any
+    file change still sitting in the debounce window at shutdown gets flushed
+    (indexed/graph-saved) instead of silently dropped.
+    """
+    handler = getattr(obs, "_cognirepo_handler", None)
+    if handler is not None:
+        handler.flush()
+    obs.stop()
+    obs.join()
+
+
 def _print_results(results):
     if isinstance(results, list):
         for r in results:
@@ -2152,8 +2166,7 @@ def _start_watcher(path: str, kg, indexer, daemon: bool = False) -> None:
         return create_watcher(abs_path, indexer, kg, behaviour, session_id)
 
     def _stop_observer(obs):
-        obs.stop()
-        obs.join()
+        _flush_and_stop_observer(obs)
 
     def _stop(signum, frame):  # pylint: disable=unused-argument
         raise KeyboardInterrupt
@@ -2202,8 +2215,7 @@ def _start_watcher_bg(path: str) -> None:
                 return create_watcher(abs_path, _indexer, _kg, _bt, _session_id)
 
             def _stop(obs):
-                obs.stop()
-                obs.join()
+                _flush_and_stop_observer(obs)
 
             run_watcher_with_crash_guard(
                 create_fn=_make,

--- a/interface/tools/retrieve_memory.py
+++ b/interface/tools/retrieve_memory.py
@@ -100,7 +100,12 @@ def _structure_results(results: list) -> dict:
         score = r.get("final_score", r.get("importance", 0.0))
         source = r.get("source", "")
 
-        if source == "ast" or (source == "semantic" and " in " in text and ":" in text):
+        # COGNIREPO-D07: hybrid.py's vector retrieval now reports the real
+        # stored source (previously hardcoded "semantic" for every vector
+        # hit, which this used to approximate via a text-shape heuristic).
+        # AST/code entries are labeled "ast" (graph reverse-index) or
+        # "symbol" (embedded AST symbols in the semantic vector store).
+        if source in ("ast", "symbol"):
             # AST hit: extract symbol + file:line
             symbol = ""
             file_path = ""

--- a/interface/tools/store_memory.py
+++ b/interface/tools/store_memory.py
@@ -76,7 +76,10 @@ def store_memory(text: str, source: str = "") -> dict:
         logger.warning("conflict detection failed: %s", _cf_exc)
 
     try:
-        mem.store(text)
+        # COGNIREPO-D08: forward the caller's source label to storage instead
+        # of silently discarding it. An empty/unspecified source (CLI default
+        # `--source ""`) still lands as "memory", matching pre-fix behavior.
+        mem.store(text, source=source or "memory")
         MEMORY_OPS_TOTAL.labels(op="store", result="ok").inc()
     except Exception:
         MEMORY_OPS_TOTAL.labels(op="store", result="error").inc()

--- a/tests/test_behaviour_tracker.py
+++ b/tests/test_behaviour_tracker.py
@@ -168,6 +168,7 @@ class TestFramingHintsLifecycle:
         from unittest.mock import Mock
         from data.graph.knowledge_graph import KnowledgeGraph
         from data.graph.behaviour_tracker import BehaviourTracker
+        from interface.tools.store_memory import store_memory
 
         cog_dir = tmp_path / ".cognirepo" / "graph"
         cog_dir.mkdir(parents=True, exist_ok=True)
@@ -175,7 +176,10 @@ class TestFramingHintsLifecycle:
         g = KnowledgeGraph()
         # Inject store_fn directly (mechanical DI, COGNIREPO-105) rather than patching
         # the module-level store_memory import that behaviour_tracker.py no longer makes.
-        store_fn = Mock(return_value=None)
+        # spec=store_memory (COGNIREPO-D04): a loosely-mocked callable would accept any
+        # kwargs and mask a signature mismatch like the pre-fix `importance=0.8` call —
+        # this asserts the call site actually matches store_memory()'s real signature.
+        store_fn = Mock(spec=store_memory, return_value={"conflicts": []})
         bt = BehaviourTracker(g, store_fn=store_fn)
         # Force patterns to a known state without triggering auto-summarize
         for i in range(9):
@@ -189,6 +193,10 @@ class TestFramingHintsLifecycle:
         assert result is True
         assert bt.data["interaction_style"]["query_patterns"] == []
         store_fn.assert_called_once()
+        # COGNIREPO-D04 AC2: framing_hints/last_summarized are actually populated —
+        # not silently skipped by a swallowed exception from a bad store_fn call.
+        assert hint != ""
+        assert bt.data["interaction_style"].get("last_summarized")
 
 
 # ── Symbol weights / hot symbols ─────────────────────────────────────────────

--- a/tests/test_check_circular_deps.py
+++ b/tests/test_check_circular_deps.py
@@ -101,7 +101,8 @@ class TestCheckCircularDeps:
     def test_head_import_graph_has_only_known_deferred_violations(self):
         """Guards against silent regression of build_import_graph.py's INTERNAL_PACKAGES
         (COGNIREPO-105 fixed a stale set that made this check always trivially pass).
-        The only allowed violations at HEAD are the two deferred to COGNIREPO-D06."""
+        COGNIREPO-D06 resolved the two core/vector_db/local_vector_db.py core→data
+        violations that were deferred here — HEAD must now have zero layer violations."""
         mod = _load_check_module()
         graph_path = REPO_ROOT / "restructure" / "import-graph.json"
         if not graph_path.exists():
@@ -126,11 +127,4 @@ class TestCheckCircularDeps:
                     continue
                 violations.append(f"{filepath}:{imp.get('lineno')}")
 
-        known_deferred = {
-            "core/vector_db/local_vector_db.py:167",
-            "core/vector_db/local_vector_db.py:265",
-        }
-        assert set(violations) == known_deferred, (
-            f"Unexpected layer violations (not in COGNIREPO-D06's known set): "
-            f"{set(violations) - known_deferred}"
-        )
+        assert not violations, f"Unexpected layer violations at HEAD: {violations}"

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -63,3 +63,61 @@ def test_daemon_start_friendly_error_on_unsupported_os(monkeypatch, tmp_path, ca
     assert "Linux only" in captured.err or "linux" in captured.err.lower(), (
         f"Expected friendly 'Linux only' message in stderr, got: {captured.err!r}"
     )
+
+
+class TestRunWatcherWithCrashGuardKeyboardInterrupt:
+    """COGNIREPO-D05: the KeyboardInterrupt branch (Ctrl+C / SIGTERM — the
+    primary real-world shutdown path, both raise KeyboardInterrupt via the
+    installed SIGTERM handler) must call stop_fn(observer) before breaking
+    out of the loop. Without this, _flush_and_stop_observer()'s flush()
+    never runs on a real shutdown and any debounced-but-unflushed edit is
+    silently dropped — confirmed by a live cognirepo watch + SIGTERM +
+    index-content check before this fix, which reproduced the exact D05
+    data-loss bug even with _stop_observer()/_stop() already patched."""
+
+    def test_stop_fn_called_on_keyboard_interrupt(self, monkeypatch):
+        from interface.cli import daemon as daemon_mod
+        from unittest.mock import MagicMock
+
+        observer = MagicMock()
+        observer.is_alive.return_value = True
+
+        def _sleep_raises(_seconds):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(daemon_mod.time, "sleep", _sleep_raises)
+        monkeypatch.setattr(daemon_mod, "start_heartbeat_thread", MagicMock())
+
+        stop_fn = MagicMock()
+        daemon_mod.run_watcher_with_crash_guard(
+            create_fn=lambda: observer,
+            stop_fn=stop_fn,
+            watcher_path="/tmp/does-not-matter",
+            session_id="test-session",
+        )
+
+        stop_fn.assert_called_once_with(observer)
+
+    def test_stop_fn_exception_does_not_propagate(self, monkeypatch):
+        """A broken stop_fn must not crash the shutdown path."""
+        from interface.cli import daemon as daemon_mod
+        from unittest.mock import MagicMock
+
+        observer = MagicMock()
+        observer.is_alive.return_value = True
+
+        def _sleep_raises(_seconds):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(daemon_mod.time, "sleep", _sleep_raises)
+        monkeypatch.setattr(daemon_mod, "start_heartbeat_thread", MagicMock())
+
+        stop_fn = MagicMock(side_effect=RuntimeError("boom"))
+        daemon_mod.run_watcher_with_crash_guard(
+            create_fn=lambda: observer,
+            stop_fn=stop_fn,
+            watcher_path="/tmp/does-not-matter",
+            session_id="test-session",
+        )  # must not raise
+
+        stop_fn.assert_called_once_with(observer)

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -87,6 +87,37 @@ class TestHybridRetriever:
         assert scores == sorted(scores, reverse=True)
 
 
+class TestVectorRetrieveSourcePreservation:
+    """COGNIREPO-D07: _vector_retrieve() must report the real stored source
+    (previously hardcoded "semantic" for every vector-backend hit)."""
+
+    def test_preserves_real_stored_source(self):
+        from intelligence.retrieval.hybrid import HybridRetriever
+        from data.memory.embeddings import encode_with_timeout
+
+        r = HybridRetriever()
+        vec = encode_with_timeout("interaction style summary text").astype("float32")
+        r.db.add(vec, "interaction style summary text", importance=0.8, source="interaction_style")
+
+        results = r._vector_retrieve(vec, k=5)
+        assert results
+        assert results[0]["source"] == "interaction_style"
+
+    def test_defaults_to_memory_when_source_missing(self):
+        from intelligence.retrieval.hybrid import HybridRetriever
+        from data.memory.semantic_memory import SemanticMemory
+        from data.memory.embeddings import encode_with_timeout
+
+        sm = SemanticMemory()
+        sm.store("plain stored memory with default source")
+
+        r = HybridRetriever()
+        vec = encode_with_timeout("plain stored memory with default source").astype("float32")
+        results = r._vector_retrieve(vec, k=5)
+        assert results
+        assert results[0]["source"] == "memory"
+
+
 class TestConcurrentCacheMiss:
     def test_concurrent_misses_call_retriever_once(self, monkeypatch):
         """N concurrent cache misses for same key → HybridRetriever.retrieve called once."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -54,6 +54,48 @@ class TestSemanticMemory:
         results = sm.retrieve("code topics", top_k=3)
         assert len(results) <= 3
 
+    # ── COGNIREPO-D08: SemanticMemory.store() must forward source ───────────
+
+    def test_store_forwards_real_source(self):
+        from data.memory.semantic_memory import SemanticMemory
+        sm = SemanticMemory()
+        sm.store("interaction style summary text", source="interaction_style")
+        results = sm.retrieve("interaction style summary text", top_k=1)
+        assert results[0]["source"] == "interaction_style"
+
+    def test_store_default_source_is_memory(self):
+        from data.memory.semantic_memory import SemanticMemory
+        sm = SemanticMemory()
+        sm.store("plain stored memory with no explicit source")
+        results = sm.retrieve("plain stored memory with no explicit source", top_k=1)
+        assert results[0]["source"] == "memory"
+
+
+class TestStoreMemoryToolSourceForwarding:
+    """COGNIREPO-D08: interface.tools.store_memory.store_memory()'s `source`
+    argument was accepted but silently discarded before storage — every
+    memory ended up with source="memory" regardless of what the caller
+    passed. These exercise the real (unmocked) store_memory() → storage
+    round trip, not just SemanticMemory directly."""
+
+    def test_real_source_is_persisted(self):
+        from interface.tools.store_memory import store_memory
+        from data.memory.semantic_memory import SemanticMemory
+
+        store_memory("a memory with a real source label", source="benchmark")
+        sm = SemanticMemory()
+        results = sm.retrieve("a memory with a real source label", top_k=1)
+        assert results[0]["source"] == "benchmark"
+
+    def test_empty_source_still_defaults_to_memory(self):
+        from interface.tools.store_memory import store_memory
+        from data.memory.semantic_memory import SemanticMemory
+
+        store_memory("a memory with no source label")
+        sm = SemanticMemory()
+        results = sm.retrieve("a memory with no source label", top_k=1)
+        assert results[0]["source"] == "memory"
+
 
 class TestEpisodicMemory:
     def test_log_and_retrieve(self):

--- a/tests/test_retrieve_memory_extended.py
+++ b/tests/test_retrieve_memory_extended.py
@@ -170,3 +170,37 @@ def test_structure_results_with_dash_section():
     }
     result = _structure_results([hit])
     assert "JWT tokens" in result["doc_hits"][0]["section"]
+
+
+# ── COGNIREPO-D07: source in ("ast", "symbol") classification ────────────────
+
+def test_structure_results_symbol_source_is_code_hit():
+    """A real vector-store AST symbol entry (source="symbol") must land in code_hits."""
+    from interface.tools.retrieve_memory import _structure_results
+    hit = {
+        "text": "FUNCTION verify_token in auth/jwt.py:88 — validates bearer token",
+        "source": "symbol",
+        "final_score": 0.7,
+    }
+    result = _structure_results([hit])
+    assert len(result["code_hits"]) == 1
+    assert result["doc_hits"] == []
+    assert result["code_hits"][0]["file"] == "auth/jwt.py"
+    assert result["code_hits"][0]["line"] == 88
+
+
+def test_structure_results_non_ast_source_with_in_colon_shape_stays_doc_hit():
+    """A real interaction_style/memory hit whose text happens to contain
+    "X in Y:Z"-shaped substrings must NOT be misclassified as a code hit —
+    only source in ("ast", "symbol") should trigger code_hits now that the
+    real stored source is available (COGNIREPO-D07)."""
+    from interface.tools.retrieve_memory import _structure_results
+    hit = {
+        "text": "User interaction style: prefers detailed answers. Common terms: auth, in, config.py:10",
+        "source": "interaction_style",
+        "final_score": 0.6,
+    }
+    result = _structure_results([hit])
+    assert result["code_hits"] == []
+    assert len(result["doc_hits"]) == 1
+    assert result["doc_hits"][0]["source"] == "interaction_style"

--- a/tests/test_storage_adapter.py
+++ b/tests/test_storage_adapter.py
@@ -129,6 +129,116 @@ class TestLocalVectorDB:
         assert adapter.metadata[0]["behaviour_score"] == 0.5
 
 
+# ── COGNIREPO-D06: breaker_factory / cleanup_queue_factory DI ────────────────
+# core/vector_db/local_vector_db.py no longer lazily imports
+# data.memory.circuit_breaker / data.memory.cleanup_queue (core→data upward
+# import). Callers now inject these via optional factories — these tests
+# confirm save()/suppress_row() behave identically to the pre-refactor
+# behavior when the real factories are wired (exercised through
+# get_vector_adapter(), not just direct LocalVectorDB() construction).
+
+class TestLocalVectorDBBreakerAndCleanupDI:
+    def _make_adapter(self, tmp_path, monkeypatch, **kwargs):
+        monkeypatch.setattr(
+            "core.vector_db.local_vector_db._index_file",
+            lambda: str(tmp_path / "semantic.index"),
+        )
+        monkeypatch.setattr(
+            "core.vector_db.local_vector_db._meta_file",
+            lambda: str(tmp_path / "semantic_metadata.json"),
+        )
+        monkeypatch.setattr("core.vector_db.local_vector_db.LocalVectorDB._load_meta", lambda self: [])
+        from core.vector_db.local_vector_db import LocalVectorDB
+        return LocalVectorDB(dim=4, **kwargs)
+
+    def test_save_checks_breaker_and_records_success(self, tmp_path, monkeypatch):
+        breaker = MagicMock()
+        adapter = self._make_adapter(tmp_path, monkeypatch, breaker_factory=lambda: breaker)
+        adapter.save()
+        breaker.check.assert_called_once()
+        breaker.record_success.assert_called_once()
+
+    def test_save_still_blocks_when_breaker_tripped(self, tmp_path, monkeypatch):
+        """Circuit breaker still trips exactly as before the D06 refactor."""
+        from data.memory.circuit_breaker import CircuitOpenError
+
+        breaker = MagicMock()
+        breaker.check.side_effect = CircuitOpenError("tripped")
+        adapter = self._make_adapter(tmp_path, monkeypatch, breaker_factory=lambda: breaker)
+        with pytest.raises(CircuitOpenError):
+            adapter.save()
+        breaker.record_success.assert_not_called()
+
+    def test_save_without_breaker_factory_is_a_noop_skip(self, tmp_path, monkeypatch):
+        """No factory injected (e.g. a raw LocalVectorDB()) — save() still succeeds."""
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        adapter.save()  # must not raise
+
+    def test_suppress_row_enqueues_cleanup_when_factory_set(self, tmp_path, monkeypatch):
+        queue = MagicMock()
+        adapter = self._make_adapter(
+            tmp_path, monkeypatch,
+            breaker_factory=lambda: MagicMock(),
+            cleanup_queue_factory=lambda: queue,
+        )
+        monkeypatch.setattr(adapter, "save", MagicMock())
+        vec = np.array([0.1, 0.2, 0.3, 0.4], dtype="float32")
+        adapter.add(vec, "dup text", importance=0.5, source="memory")
+
+        ok = adapter.suppress_row(0, reason="auto_superseded", similarity=0.92)
+
+        assert ok is True
+        assert adapter.metadata[0]["suppressed"] is True
+        queue.push.assert_called_once()
+        _, kwargs = queue.push.call_args
+        assert kwargs["entry_id"] == 0
+        assert kwargs["store"] == "semantic"
+        assert kwargs["similarity_score"] == 0.92
+
+    def test_suppress_row_without_cleanup_factory_still_suppresses(self, tmp_path, monkeypatch):
+        """No cleanup_queue_factory injected — row is still suppressed, just not enqueued."""
+        adapter = self._make_adapter(tmp_path, monkeypatch)
+        monkeypatch.setattr(adapter, "save", MagicMock())
+        vec = np.array([0.1, 0.2, 0.3, 0.4], dtype="float32")
+        adapter.add(vec, "dup text", importance=0.5, source="memory")
+
+        ok = adapter.suppress_row(0)
+
+        assert ok is True
+        assert adapter.metadata[0]["suppressed"] is True
+
+    def test_get_vector_adapter_wires_real_breaker_and_cleanup_queue(self, tmp_path, monkeypatch):
+        """AC3: going through get_vector_adapter() with real factories behaves like before."""
+        from data.memory.circuit_breaker import get_breaker
+        from data.memory.cleanup_queue import CleanupQueue
+        from core.vector_db.local_vector_db import LocalVectorDB
+
+        monkeypatch.setattr(
+            "core.vector_db.factory._find_config",
+            lambda: None,
+        )
+        monkeypatch.setattr("core.vector_db.factory._read_backend", lambda: "faiss")
+        monkeypatch.setattr(
+            "core.vector_db.local_vector_db._index_file",
+            lambda: str(tmp_path / "semantic.index"),
+        )
+        monkeypatch.setattr(
+            "core.vector_db.local_vector_db._meta_file",
+            lambda: str(tmp_path / "semantic_metadata.json"),
+        )
+        monkeypatch.setattr("core.vector_db.local_vector_db.LocalVectorDB._load_meta", lambda self: [])
+
+        from core.vector_db.factory import get_vector_adapter
+        adapter = get_vector_adapter(
+            breaker_factory=get_breaker,
+            cleanup_queue_factory=CleanupQueue,
+        )
+        assert isinstance(adapter, LocalVectorDB)
+        assert adapter._breaker_factory is get_breaker
+        assert adapter._cleanup_queue_factory is CleanupQueue
+        adapter.save()  # exercises the real breaker end-to-end, must not raise
+
+
 # ── ChromaDBAdapter ───────────────────────────────────────────────────────────
 
 class TestChromaDBAdapter:

--- a/tests/test_watcher_debounce.py
+++ b/tests/test_watcher_debounce.py
@@ -118,3 +118,40 @@ class TestDebounceBatching:
 
         indexer.index_file.assert_called_once()
         indexer.save.assert_called_once()
+
+
+class TestShutdownFlush:
+    """COGNIREPO-D05: a pending debounced event must be flushed before the
+    observer stops — both real shutdown call sites (foreground `cognirepo
+    watch` and the MCP-launched background watcher) delegate to the same
+    interface.cli.main._flush_and_stop_observer() helper.
+    """
+
+    def test_flush_and_stop_observer_flushes_pending_before_stop(self, tmp_path):
+        from interface.cli.main import _flush_and_stop_observer
+
+        handler, indexer, kg, behaviour = _make_handler(tmp_path, debounce_ms=5000)
+        f = tmp_path / "auth.py"
+        f.write_text("def verify_token(): pass")
+        handler.on_modified(FileModifiedEvent(str(f)))
+        assert indexer.index_file.call_count == 0  # still inside the debounce window
+
+        obs = MagicMock()
+        obs._cognirepo_handler = handler
+
+        _flush_and_stop_observer(obs)
+
+        # The queued edit was indexed (flushed) before the observer was stopped.
+        indexer.index_file.assert_called_once()
+        indexer.save.assert_called_once()
+        obs.stop.assert_called_once()
+        obs.join.assert_called_once()
+
+    def test_flush_and_stop_observer_tolerates_missing_handler(self):
+        """An observer without _cognirepo_handler (e.g. a bare test double) still stops cleanly."""
+        from interface.cli.main import _flush_and_stop_observer
+
+        obs = MagicMock(spec=["stop", "join"])
+        _flush_and_stop_observer(obs)
+        obs.stop.assert_called_once()
+        obs.join.assert_called_once()


### PR DESCRIPTION
Bundled per explicit user direction: one branch/PR for all defects found while testing `COGNIREPO-105`, targeting the story branch (not `development`) so the user can test `story/COGNIREPO-105` as a whole before merging to `development` themselves.

Tickets:
- `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D04/COGNIREPO-D04.md`
- `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D05/COGNIREPO-D05.md`
- `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D06/COGNIREPO-D06.md`
- `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D07/COGNIREPO-D07.md` (filed during this pass — see below)
- `JIRA/EPIC-ReliabilityGate-100/DEFECT/COGNIREPO-D08/COGNIREPO-D08.md` (filed during this pass — see below)

## What changed

**COGNIREPO-D04** — `summarize_interaction_style()` called `store_fn(summary, source="interaction_style", importance=0.8)`, but `store_memory()` has no `importance` kwarg — every real call raised `TypeError`, swallowed by a blanket `except Exception`. Dropped the kwarg; replaced the loosely-mocked `store_fn` in `test_summarize_interaction_style_direct_call` with `Mock(spec=store_memory)` so a signature mismatch fails the test instead of masking it.
- [x] AC1: real `store_fn=store_memory` call stores a semantic memory, returns `True`
- [x] AC2: `framing_hints`/`last_summarized` populated
- [x] AC3: masking mock replaced

**COGNIREPO-D05** — `RepoFileHandler.flush()`'s shutdown-flush contract was wired into `BehaviourTracker.stop_watching()`, which COGNIREPO-105 correctly identified as dead code (zero callers) and deleted — but neither real shutdown path (`cognirepo watch`'s `_stop_observer`, the MCP-launched background watcher's `_run()._stop`) ever called `flush()`. Added `_flush_and_stop_observer()` in `interface/cli/main.py`, wired into both call sites — **but a live TC-D05-1 walkthrough (real `cognirepo watch` + edit + SIGTERM + `ast_index.json` inspection) proved that patch alone insufficient**: `run_watcher_with_crash_guard()`'s `except KeyboardInterrupt` branch (the one SIGTERM/Ctrl+C actually take) never called `stop_fn(observer)` at all, only the crash branch did — so the flush never ran on the real shutdown path. Fixed `interface/cli/daemon.py` to also call `stop_fn` there. Re-ran the live walkthrough: PASS (index sha256 for the edited file matches post-edit content, new symbol present).
- [x] AC1/AC2: flush wired into both shutdown paths, verified live (not just automated) — see TEST_SUITE for the full before/after walkthrough
- [x] AC3: `tests/test_watcher_debounce.py` + new `tests/test_cli_daemon.py::TestRunWatcherWithCrashGuardKeyboardInterrupt` stay green

**COGNIREPO-D06** — `core/vector_db/local_vector_db.py` lazily imported `data.memory.circuit_breaker`/`cleanup_queue` (core→data violation), surfaced after COGNIREPO-105 fixed `build_import_graph.py`'s stale package set. Threaded `breaker_factory`/`cleanup_queue_factory` (keyword-only, default `None`) through `LocalVectorDB.__init__` and `get_vector_adapter()`, wired at every real call site that reaches `save()`/`suppress_row()` (`semantic_memory.py`, `auto_store.py`, `doc_ingester.py`).
- [x] AC1: zero `core→data` imports (`check_circular_deps.py` reports 0 violations, down from 2)
- [x] AC2/AC3: circuit breaker + cleanup queue behavior unchanged for all real callers, verified via a real `SemanticMemory()`-wired script (breaker trip → `save()` raises `CircuitOpenError`; `suppress_row()` → row enqueued in `CleanupQueue`) plus regression tests through `get_vector_adapter()`

**COGNIREPO-D07** *(found while re-verifying TC-105-1, not in the original PR body)* — `HybridRetriever._vector_retrieve()` hardcoded `"source": "semantic"` on every vector hit, discarding the real stored source. Fixed to preserve it; updated `retrieve_memory.py`'s `_structure_results()` to classify code_hits via the now-accurate `source in ("ast", "symbol")` instead of a text-shape approximation. `context_pack.py` already keyed off `source == "ast"` specifically — unaffected.

**COGNIREPO-D08** *(found while re-verifying TC-105-1, not in the original PR body)* — `store_memory()`'s `source` argument was accepted but never forwarded to `SemanticMemory.store()`, which always persisted with the default `source="memory"`. `SemanticMemory.store()` now accepts and forwards `source`; `store_memory()` passes `source=source or "memory"` (preserving the empty-source default).

## TC-105-1 re-verification

D04 alone wasn't enough — D07 and D08 were both silently defeating it too. All three fixed, then re-ran the exact scenario end-to-end (real `BehaviourTracker`, real `store_memory`, real `retrieve_memory`, isolated `.cognirepo` fixture):

```
Total hits: 1
interaction_style-sourced hits: 1
 - User interaction style: prefers concise answers. ... | source= interaction_style
TC-105-1: PASS
```

See `JIRA/EPIC-ReliabilityGate-100/STORY/COGNIREPO-105/TEST/COGNIREPO-105-TEST_SUITE.md`'s re-verification section.

## Test plan
- [x] `venv/bin/python -m pytest tests/ -q` — 1251 passed, 5 skipped (baseline before this branch: 1227 passed, 5 skipped)
- [x] `grep -rn "from interface" data/ intelligence/ core/ --include='*.py'` — clean
- [x] `scripts/build_import_graph.py .` + `scripts/check_circular_deps.py restructure/import-graph.json --verbose` — 0 violations
- [x] Manual TC-D04-1, TC-D06-1, TC-D06-2, TC-D07-1, TC-D07-2, TC-D08-1, TC-D08-2 executed directly — all PASS (see each defect's TEST_SUITE.md)
- [x] TC-D05-1 (live `cognirepo watch` + real edit + real SIGTERM, verified via `ast_index.json` since `verify-index`'s DIRTY check doesn't reflect watcher flushes) — executed live against `cognirepo_test_repo/easy/flask`; first run caught the `run_watcher_with_crash_guard` KeyboardInterrupt gap, second run after the fix PASSED

Does not merge to `development` — targets `story/COGNIREPO-105` per user request; they'll test the combined story branch and push to `development` themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)