### PR TITLE
COGNIREPO-100: sign off COGNIREPO-106

### DIFF
--- a/JIRA/EPIC-ReliabilityGate-100/status.yml
+++ b/JIRA/EPIC-ReliabilityGate-100/status.yml
@@ -27,10 +27,10 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/39
     test_status: pass  # TC-105-1 originally FAILed; re-verified pass via defect/COGNIREPO-D04_D05_D06 + COGNIREPO-D09 (see its TEST_SUITE.md). Merged to development.
   - id: COGNIREPO-106
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-106
     pr: https://github.com/ashlesh-t/cognirepo/pull/41
-    test_status: pass
+    test_status: pass  # PR #41 merged, CI green, no review comments
 defects:
   - id: COGNIREPO-D01
     status: signed-off


### PR DESCRIPTION
Mechanical status.yml update: PR #41 (COGNIREPO-106) merged, CI green, zero review comments. Marks the story `signed-off`.

All EPIC-ReliabilityGate-100 stories (101-106) and defects (D01-D09) are now signed off. The epic itself is **not** ready to sign off — `COGNIREPO-100-TEST_SUITE.md`'s three E2E cases require live, manual, multi-step verification (corruption drills, burst-save timing, cross-artifact tool-discovery parity against a running MCP server) that only you can execute per `skill.md` step 4. Let me know when you'd like to run those, or if you'd rather I attempt them.