### PR TITLE
COGNIREPO-D13/D14/D15/D16: fix concurrent index-write corruption, timestamp drift, flush race, dead watcher probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Fixed
+- **COGNIREPO-D13 — concurrent index writes could crash the watcher or promote
+  truncated JSON.** `ASTIndexer._atomic_json_dump()` derived its scratch filename
+  from the target path (`ast_index.json.tmp`), so every concurrent writer — two
+  watcher flush threads, a second `cognirepo serve`, or the background
+  `index-repo --changed-only` that `graph_stats` spawns — shared one file. The
+  loser of the rename race raised `FileNotFoundError`; worse, an interleaved
+  `open(tmp, "w")` truncated a file another writer was mid-`json.dump()` into, and
+  that partial JSON was then `os.replace()`d into place. Scratch files now come
+  from `tempfile.mkstemp()` and are unlinked if the write fails. `ASTIndexer.save()`
+  additionally holds `store_lock()` across the whole group (`ast_index.json`,
+  `ast.index`, `ast_metadata.json`, `manifest.json`) so two processes cannot
+  interleave their renames and leave `manifest.json`'s checksums describing a
+  different index than the one on disk — `KnowledgeGraph.save()` has always taken
+  this lock; `ASTIndexer.save()` did not. `load()` sweeps scratch files stranded
+  by a hard kill, including the legacy fixed-name `.tmp`.
+- **COGNIREPO-D14 — `graph_stats` reported two clocks in one payload.**
+  `indexed_at` was stamped only by a full `index_repo()` run, never by the
+  watcher's incremental `save()`, so a repo kept current by the watcher returned
+  an hours-old `last_indexed` alongside `index_age_minutes: 0`. `save()` now
+  stamps `indexed_at` on every persist, and a new `full_indexed_at` field carries
+  the last complete sweep separately. `graph_stats` returns both, plus
+  `watcher_alive`.
+- **COGNIREPO-D15 — overlapping watcher flushes; a failed save abandoned the
+  batch.** `threading.Timer.cancel()` is a no-op once the timer has fired, so a
+  burst outlasting the debounce window scheduled a second `flush()` while the
+  first was still inside the seconds-long index+save section; both threads then
+  mutated shared `indexer.index_data` / `graph.G` and called `save()` at once.
+  `flush()` is now serialized by a dedicated lock (as is the `debounce_ms=0`
+  synchronous path). Separately, `indexer.save()` sat outside any handler, so a
+  raise from it skipped `graph.save()`, the D12 audit trail, episodic
+  `mark_stale()`, and `invalidate_hybrid_cache()` — leaving the graph, index and
+  retrieval cache mutually inconsistent with no record. Each step is now
+  independently guarded, and `last_watcher_reindex.json` gained an `error` field
+  so a partially-applied batch is no longer indistinguishable from a clean one.
+- **COGNIREPO-D16 — `_watcher_alive()` was hardwired to `False`.** It read
+  `.cognirepo/watcher.pid`, a path nothing in the codebase has ever written (the
+  daemon registers under `.cognirepo/watchers/<pid>.json`). The
+  "a live watcher means the index is not stale" guard in `graph_stats` was
+  therefore dead, letting it spawn a competing `index-repo --changed-only`
+  against a repo an active watcher was already writing — feeding D13 a third
+  concurrent writer. Now reads the heartbeat that `run_watcher_with_crash_guard()`
+  refreshes for both the daemon and the in-process auto-watcher, with the PID
+  registry as fallback.
+
 ### Removed
 - **`interface.cli.docs_index` backward-compat shim** — deleted. It re-exported
   `intelligence.indexer.docs_index` and had warned `DeprecationWarning: ... Removed in v2.0`

--- a/JIRA/EPIC-ReliabilityGate-100/COGNIREPO-100-TEST_SUITE.md
+++ b/JIRA/EPIC-ReliabilityGate-100/COGNIREPO-100-TEST_SUITE.md
@@ -16,49 +16,87 @@ Story-level suites cover each fix in isolation; these verify the epic works as a
   deleted function absent from lookup AND no orphan node counted; verify-index exits 1 with a
   DIRTY line; doctor green apart from the intentional dirty warning.
 Obtained results (verified against filesystem/pickle, not just tool text):
+Actions performed:
+1. Burst-saved lib/ansible/utils/version.py 5× in <1s (appended marker comments)
+2. git mv lib/ansible/utils/shlex.py → shlex_renamed.py
+3. Deleted colorize() from lib/ansible/utils/color.py
+4. Ran cognirepo verify-index with all 3 edits uncommitted
+5. Ran cognirepo doctor
 
-#: 1
-Expected: One reindex logged for the burst
-Obtained: last_indexed.json unchanged (2026-07-20T19:57:03, pre-dates burst).
-.cognirepo/bg_tasks/ empty. No watcher log file exists. Yet ast_index.json content
-was silently patched in place (network_renamed.py present, count_terms gone) with
-zero log trail.
-Result: FAIL — mutation happened, no log entry anywhere
-────────────────────────────────────────
-#: 2
-Expected: Renamed symbol found at new path only
-Obtained: lookup_symbol("to_netmask") → {"file":
-"lib/ansible/module_utils/common/network_renamed.py", "line": 40, "type":
-"FUNCTION"}. Confirmed old path network.py absent from ast_index.json["files"]
-entirely (checked directly).
-Result: PASS
-────────────────────────────────────────
-#: 3
-Expected: Deleted function absent from lookup AND no orphan node
-Obtained: lookup_symbol("count_terms") → empty (absent, half-pass). But
-subgraph("count_terms") → symbol::count_terms CONCEPT node still live with 4 CALLS +
-4 CALLED_BY edges to
-check_mutually_exclusive/check_required_one_of/check_required_together/check_required_if.
-Result: FAIL — orphan node confirmed present in graph
-────────────────────────────────────────
-#: 4
-Expected: verify-index exits 1 with a DIRTY line
-Obtained: EXIT_CODE=0, output OK 17343 symbols · 4114 files · commit bd7fa60c2413 ·
-indexed ... — no DIRTY line, no nonzero exit, despite 3 uncommitted mutations (git
-status confirms R/M/M present at call time).
-Result: FAIL
-────────────────────────────────────────
-#: 5
-Expected: doctor green apart from intentional dirty warning
-Obtained: 2 warnings shown, neither is the dirty-tree warning: (a) missing API keys —
-pre-existing/unrelated, (b) graph.pkl.corrupt-1784570101 quarantined — pre-existing
-corruption, unrelated to this test. Bonus defect not in scope: FAISS 17,342 vs
-manifest 17343 symbol-count mismatch. Zero mention of the rename/edit/delete.
-Result: FAIL — wrong warnings surfaced, correct one never fired
+Obtained results (filesystem/log-verified, not just tool text)
 
-Verdict: FAIL (1/5 pass).
+Check: lookup_symbol("colorize")
+Result: Empty — no output. Confirmed at raw-file level too: grep -c '"name":
+*"colorize"' on .cognirepo/index/ast_index.json → 0. Correctly removed.
+────────────────────────────────────────
+Check: lookup_symbol("shlex_split")
+Result: Found at lib/ansible/utils/shlex_renamed.py:24 — correctly resolved to new path
+only.
+────────────────────────────────────────
+Check: graph_stats
+Result: 17,592 nodes / 96,42 but last_indexed field stuck
 
-The only behavior that matched spec was symbol resolution following the rename. Everything gating "did the tool notice the dirty state" failed: no reindex log, verify-index blind to 3 live mutations (exit 0, no DIRTY), doctor blind to the same mutations (its 2 warnings are unrelated pre-existing issues), and the deleted function left a live orphan node in the graph despite disappearing from lookup_symbol.
+at 2026-07-21T16:31:07, whic recorded in manifest.json
+(18:20:10). Timestamp is stapdated.
+────────────────────────────
+Check: cognirepo verify-inde
+Result: Exit code 1, DIRTY les (color.py,
+shlex_renamed.py, version.py
+────────────────────────────
+Check: cognirepo doctor
+Result: Exit code 1, 3 warning-tree warning, plus "no API
+
+keys configured" and "doc chexisting environment
+conditions, not caused by th was not "green apart from
+the intentional dirty warnin
+────────────────────────────
+Check: Watcher log (watch_17
+Result: Two threads crashed replace(ast_index.json.tmp →
+ast_index.json) — a race whetriggered by the
+
+- **ROOT CAUSE (analysed 2026-07-22) — 4 defects, fixed on
+  `defect/COGNIREPO-D13_D14_D15_D16`.**
+
+  - **D13 (P0, silent corruption).** `ASTIndexer._atomic_json_dump()` derived its scratch
+    filename from the target path, so all concurrent writers shared one `ast_index.json.tmp`.
+    Two failure modes: the loser of the rename race raises `FileNotFoundError` (the crash
+    logged above — the *benign* variant), and an interleaved `open(tmp,"w")` truncates a file
+    another writer is mid-`json.dump()` into, promoting partial JSON into place. The latter is
+    the "parse error at char 73M" the atomic-write commit was written to fix; it narrowed the
+    window without closing it. Fix: `tempfile.mkstemp()` per writer + `store_lock()` across the
+    whole four-file group in `save()`, matching what `KnowledgeGraph.save()` already did.
+  - **D14 (P1) — the 16:31:07 vs 18:20:10 gap is real.** `indexed_at` is stamped only at
+    `ast_indexer.py::index_repo`, never by `save()`, so the watcher's incremental path left it
+    frozen while `_write_manifest()` stamped `_now()` on every save. Worse, `graph_stats`
+    returned `last_indexed` (last *full* index) and `index_age_minutes` (file mtime) in the
+    same dict — two clocks. Fix: stamp on every `save()`; add `full_indexed_at` for the last
+    complete sweep.
+  - **D15 (P0).** `flush()` held `self._lock` only while draining `_pending`, releasing it
+    before the seconds-long index+save section; `Timer.cancel()` is a no-op once fired, so a
+    burst outlasting the debounce window ran two flush bodies concurrently. Also
+    `indexer.save()` sat outside any handler, so its failure skipped `graph.save()`, the D12
+    audit trail, `mark_stale()` and `invalidate_hybrid_cache()` — producing exactly the
+    cross-store divergence this test exists to detect, with no trace in
+    `last_watcher_reindex.json`. Fix: `_flush_lock` + per-step guards + an `error` field in
+    the audit record.
+  - **D16 (P1, latent).** `_watcher_alive()` read `.cognirepo/watcher.pid`, which nothing
+    writes, so it always returned `False` and `graph_stats` could spawn a competing
+    `index-repo --changed-only` against a live watcher — a third concurrent writer feeding
+    D13. Did not fire in this run only because `index_age_minutes ≈ 0`.
+
+  **Test-suite defect:** the expected result "doctor green apart from the intentional dirty
+  warning" is unachievable in an environment with no API keys and incomplete doc coverage, and
+  cannot distinguish a regression from ambient noise. Restate as a delta assertion: capture
+  `doctor` output before the mutations and assert the only *new* warnings after are the
+  dirty-tree ones.
+
+  **Coverage gap that let this ship:** `tests/test_watcher_debounce.py` mocks `indexer.save`,
+  so no watcher test ever reached the real writer, and every case asserts the debounce
+  *collapse* property rather than constructing overlapping flushes. New regression suite
+  `tests/test_index_write_concurrency.py` (11 tests) drives the real writer; 10 of the 11 fail
+  against the pre-fix code, reproducing the logged `FileNotFoundError` verbatim.
+
+
 
 ## E2E-100-2: Tool discovery parity across all artifacts (crosses D01+101+106)
 - Test repo: /home/ashlesh/my_works/cognirepo (this repo)
@@ -69,7 +107,66 @@ The only behavior that matched spec was symbol resolution following the rename. 
 - Expected results: all five sources agree on the same 34 names (incl. find_symbol_path,
   get_service_endpoints); client lists 34.
 - Obtained results:
-- Verdict:
+  Ran `cognirepo export-spec` first. Source of truth = 34 `@mcp.tool()`-decorated functions
+  in `interface/server/mcp_server.py` (arch_overview, context_pack, cross_repo_search,
+  cross_repo_traverse, dependency_graph, episodic_search, explain_change, find_symbol_path,
+  get_agent_bootstrap, get_error_patterns, get_last_context, get_service_endpoints,
+  get_session_brief, get_session_history, get_user_profile, graph_stats, link_repos,
+  list_org_context, log_episode, lookup_symbol, org_dependencies, org_search, org_wide_search,
+  record_decision, record_error, record_user_preference, retrieve_memory, search_docs,
+  search_token, semantic_search_code, store_memory, subgraph, supersede_learning, who_calls).
+
+  Set-compared each artifact against source:
+  | Source | Count | Diff |
+  |---|---|---|
+  | interface/server/manifest.json | 34 | none |
+  | glama.json | 34 | none |
+  | interface/adapters/openai_tools.json | 34 | none |
+  | docs/MCP_TOOLS.md headers | 34 | none |
+  | Raw MCP `tools/list` (fresh `cognirepo serve` spawned, JSON-RPC `initialize`+`tools/list`
+    sent directly over stdio) | 34 | none |
+  | This session's live client (`claude mcp list` / `claude mcp get cognirepo-cognirepo` →
+    `✔ Connected`; `ToolSearch` for any cognirepo tool name, incl. `select:context_pack,
+    lookup_symbol,get_session_brief,store_memory,who_calls`) | **0** | **34 missing** |
+
+  find_symbol_path and get_service_endpoints present in all five static artifacts and in the
+  raw server handshake — no drift there. The server process itself is healthy: a clean stdio
+  handshake against a freshly spawned `cognirepo serve` returns the correct 34/34 names,
+  identical to the decorated-function set.
+
+- Verdict: FAIL — not a spec/manifest drift issue (4/4 static artifacts + raw server response
+  agree exactly, 34/34). Failure is on the "reconnect the MCP client" step: this session's
+  transport reports the server as Connected but exposes zero CogniRepo tools — a client-side
+  staleness bug where "Connected" status does not guarantee the tool list was (re)loaded into
+  the active session. Could not fully confirm whether a true session restart resolves it, since
+  no in-session mechanism exists to force a client-side MCP reconnect/tool-cache eviction —
+  flag as a retest item requiring a fresh session process.
+
+- **ROOT CAUSE (corrected 2026-07-22) — environment/config, NOT a product defect and NOT a
+  client staleness bug.** `.mcp.json` registers `cognirepo-cognirepo` at *project* scope.
+  Claude Code gates project-scoped servers behind a one-time per-project approval recorded in
+  `~/.claude.json → projects["/home/ashlesh/my_works/cognirepo"].enabledMcpjsonServers`.
+  Both that list and `disabledMcpjsonServers` are **empty** — the approval was never granted,
+  so the server is never loaded into any session. `claude mcp list` bypasses that gate
+  entirely: it reads the config file and spawns the process itself for a health check, which
+  is why it prints `✔ Connected` next to a session exposing zero tools. The two signals come
+  from different code paths and only one consults the approval state.
+
+  Timed raw stdio handshake against a freshly spawned `cognirepo serve`: `initialize` reply at
+  0.55 s, `tools/list` reply at 0.55 s, 34 tools — so a startup/timeout explanation is also
+  ruled out. The failure is deterministic, not session-specific; it reproduces in every new
+  session until approval is granted.
+
+  Fix (either): `claude mcp reset-project-choices`, restart, and answer the approval prompt;
+  or move the server to user scope —
+  `claude mcp add -s user cognirepo-cognirepo /home/ashlesh/.local/bin/cognirepo serve
+  --project-dir /home/ashlesh/my_works/cognirepo`.
+
+  **Retest required under a corrected premise.** The assertion this test actually owns —
+  artifact/spec parity — *passed* (5/5 sources at 34/34, including the raw server response).
+  Only the client-reconnect step failed, for an environment reason unrelated to the epic.
+  Test-suite defect: the prerequisites must assert `enabledMcpjsonServers` contains the server,
+  so an unapproved config fails as a setup error instead of masquerading as tool-discovery drift.
 
 ## E2E-100-3: Corruption recovery drill (crosses 103+D02)
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy
@@ -81,5 +178,6 @@ The only behavior that matched spec was symbol resolution following the rename. 
   corrupted or duplicated."
 - Expected results: server starts; graph.pkl.corrupt-<ts> exists; doctor flags it; episodic
   search returns unique IDs (no collisions), archive intact.
-- Obtained results:
-- Verdict:
+Verdict: PASS. Corruption was detected and quarantined with a timestamped .corrupt- file rather than crashing or silently loading garbage. Graph state correctly reset to empty instead of deserializing corrupt bytes. Episodic rotation split cleanly at the threshold with zero ID collisions and no data loss in the archive.
+
+One gap worth noting: the watch --ensure-running supervisor does not restart a killed serve process — recovery depended on you manually reconnecting via /mcp. If unattended crash-recovery is a requirement, that's a real hole, not just a drill artifact.  

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -325,7 +325,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-89 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+90 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. The 89-file count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -196,7 +196,8 @@ Record a significant event to the append-only episodic log.
 
 **Signature:** `graph_stats() → dict`
 
-Return node/edge count and health summary of the knowledge graph.
+Return node/edge count and health summary of the knowledge graph, plus index
+freshness.
 
 **Output:**
 ```json
@@ -204,9 +205,28 @@ Return node/edge count and health summary of the knowledge graph.
   "nodes": 1243,
   "edges": 4871,
   "node_types": { "FUNCTION": 892, "CLASS": 201, "FILE": 150 },
-  "healthy": true
+  "healthy": true,
+  "last_indexed": "2026-07-22T18:20:10+00:00",
+  "full_indexed_at": "2026-07-22T16:31:07+00:00",
+  "index_age_minutes": 0,
+  "index_stale": false,
+  "watcher_alive": true
 }
 ```
+
+**Freshness fields:**
+
+| Field | Meaning |
+|---|---|
+| `last_indexed` | Timestamp of the most recent index write of *any* kind, including a watcher's single-file incremental save. Tracks the same event as `index_age_minutes`. |
+| `full_indexed_at` | Timestamp of the last complete `index_repo()` sweep. Older than `last_indexed` whenever the watcher has applied incremental edits since. |
+| `index_age_minutes` | Age of `ast_index.json` on disk. |
+| `index_stale` | True when the index is older than 60 min, no watcher is live, and git HEAD has moved past the last indexed SHA. |
+| `watcher_alive` | True when a watcher process (either the `cognirepo watch` daemon or the in-process auto-watcher `serve` starts) has refreshed its heartbeat within the last 120 s. |
+
+Before COGNIREPO-D14, `last_indexed` only advanced on a full `index_repo()`
+run, so a repo kept current by the watcher reported a hours-old
+`last_indexed` next to `index_age_minutes: 0` — two clocks in one payload.
 
 ---
 

--- a/intelligence/indexer/ast_indexer.py
+++ b/intelligence/indexer/ast_indexer.py
@@ -33,6 +33,7 @@ import logging
 import os
 import platform
 import subprocess
+import tempfile
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -68,6 +69,26 @@ def _ast_meta_file() -> str:
 
 def _manifest_file() -> str:
     return get_path("index/manifest.json")
+
+
+def _store_lock_or_null():
+    """Return the cross-process store lock, or a no-op context if unavailable.
+
+    store_lock() hard-raises ImportError when filelock is missing. filelock is
+    a declared dependency, but save() runs on the watcher's hot path where a
+    hard failure loses the whole batch — so a minimal install degrades to
+    unlocked writes with a warning instead of crashing the watcher.
+    """
+    try:
+        from core.config.lock import store_lock  # pylint: disable=import-outside-toplevel
+        return store_lock()
+    except ImportError:
+        log.warning(
+            "filelock unavailable — index writes are NOT protected against "
+            "concurrent processes. Run: pip install filelock"
+        )
+        import contextlib  # pylint: disable=import-outside-toplevel
+        return contextlib.nullcontext()
 
 _SKIP_DIRS: frozenset[str] = frozenset({
     # Version control
@@ -1245,6 +1266,11 @@ class ASTIndexer:
         repo_root = os.path.abspath(repo_root)
         self.index_data["repo_root"] = repo_root
         self.index_data["indexed_at"] = _now()
+        # `indexed_at` is refreshed by every save() (including the watcher's
+        # incremental path); `full_indexed_at` marks only a complete
+        # index_repo() sweep, so agents can still tell "everything was
+        # rebuilt" from "one file was touched". See COGNIREPO-D14.
+        self.index_data["full_indexed_at"] = self.index_data["indexed_at"]
 
         skip_dirs = _effective_skip_dirs()
 
@@ -2065,6 +2091,7 @@ class ASTIndexer:
             "files": {}, "reverse_index": {},
             "repo_root": self.index_data.get("repo_root", ""),
             "indexed_at": self.index_data.get("indexed_at", ""),
+            "full_indexed_at": self.index_data.get("full_indexed_at", ""),
         }
         self._pending_embeds = []  # pylint: disable=attribute-defined-outside-init
         gc.collect()
@@ -2073,18 +2100,66 @@ class ASTIndexer:
 
     @staticmethod
     def _atomic_json_dump(obj, path: str) -> None:
-        """Write JSON to a tmp file then os.replace() into place.
+        """Write JSON to a unique tmp file then os.replace() into place.
 
-        A crash or concurrent reindex mid-write can no longer leave a
-        truncated/corrupt JSON file behind (observed as a parse error at
-        char 73M on a large-monorepo ast_index.json).
+        The tmp filename MUST be unique per writer. A deterministic
+        `path + ".tmp"` is shared by every concurrent writer — two watcher
+        flush threads, a second `cognirepo serve`, or the background
+        `index-repo --changed-only` that graph_stats spawns — which produced
+        two distinct failures (COGNIREPO-D13):
+
+          1. loud: writer B's os.replace() raises FileNotFoundError because
+             writer A already renamed the shared tmp away;
+          2. silent: writer B's open(tmp, "w") truncates the file A is
+             mid-json.dump() into, and A then fsyncs and promotes a partial
+             JSON into place — the "parse error at char 73M on a
+             large-monorepo ast_index.json" this function was written to fix.
+
+        mkstemp() in the destination directory gives every writer its own
+        scratch file, so the only shared operation is the atomic rename.
+        Callers that need the *group* of index files to be mutually
+        consistent must additionally hold store_lock() — see save().
         """
-        tmp_path = path + ".tmp"
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            json.dump(obj, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, path)
+        directory = os.path.dirname(path) or "."
+        fd, tmp_path = tempfile.mkstemp(
+            dir=directory, prefix=os.path.basename(path) + ".", suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(obj, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            # Never leave an orphaned scratch file behind on failure.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _sweep_stale_tmp(path: str) -> None:
+        """Delete orphaned `<path>.*.tmp` scratch files left by a crashed write.
+
+        _atomic_json_dump() cleans up its own tmp on failure, but a SIGKILL
+        or power loss mid-write can still strand one. They are never valid
+        index state, so removing them on load() keeps the index dir clean.
+        Also removes the legacy fixed-name `<path>.tmp` from before D13.
+        """
+        directory = os.path.dirname(path) or "."
+        base = os.path.basename(path)
+        try:
+            entries = os.listdir(directory)
+        except OSError:
+            return
+        for name in entries:
+            if name == base + ".tmp" or (name.startswith(base + ".") and name.endswith(".tmp")):
+                try:
+                    os.unlink(os.path.join(directory, name))
+                    log.debug("removed orphaned index scratch file %s", name)
+                except OSError:
+                    pass
 
     @staticmethod
     def _load_json_self_heal(path: str, default):
@@ -2108,18 +2183,33 @@ class ASTIndexer:
         """Persist AST index, FAISS index, and metadata to disk.
         Also writes manifest.json with git SHA, platform info, and checksums
         so `cognirepo verify-index` can detect staleness or corruption later.
-        """
-        os.makedirs(os.path.dirname(_ast_index_file()), exist_ok=True)
-        self._atomic_json_dump(self.index_data, _ast_index_file())
-        if self.faiss_index is not None:
-            faiss.write_index(self.faiss_index, _ast_faiss_file())
-        self._atomic_json_dump(self.faiss_meta, _ast_meta_file())
 
-        # Write integrity manifest after all index files are on disk
-        repo_root = self.index_data.get("repo_root") or None
-        file_count = len(self.index_data.get("files", {}))
-        symbol_count = self.index_data.get("total_symbols", len(self.faiss_meta))
-        _write_manifest(repo_root=repo_root, symbol_count=symbol_count, file_count=file_count)
+        Holds store_lock() across the whole group (ast_index.json, ast.index,
+        ast_metadata.json, manifest.json). Per-file atomic renames alone are
+        not enough: without the lock, two processes can interleave their four
+        renames and leave manifest.json's checksums describing a different
+        ast_index.json than the one on disk, so `verify-index` reports
+        corruption that never actually happened. KnowledgeGraph.save() has
+        always taken this lock; ASTIndexer.save() did not. See COGNIREPO-D13.
+        """
+        with _store_lock_or_null():
+            os.makedirs(os.path.dirname(_ast_index_file()), exist_ok=True)
+            # Stamp every persist, not just full index_repo() runs. Without
+            # this the watcher's incremental path leaves `indexed_at` frozen
+            # at the last full index while the file mtime advances, so
+            # graph_stats reported "last indexed 2h ago" and
+            # "index_age_minutes: 0" in the same payload. See COGNIREPO-D14.
+            self.index_data["indexed_at"] = _now()
+            self._atomic_json_dump(self.index_data, _ast_index_file())
+            if self.faiss_index is not None:
+                faiss.write_index(self.faiss_index, _ast_faiss_file())
+            self._atomic_json_dump(self.faiss_meta, _ast_meta_file())
+
+            # Write integrity manifest after all index files are on disk
+            repo_root = self.index_data.get("repo_root") or None
+            file_count = len(self.index_data.get("files", {}))
+            symbol_count = self.index_data.get("total_symbols", len(self.faiss_meta))
+            _write_manifest(repo_root=repo_root, symbol_count=symbol_count, file_count=file_count)
 
     def load(self) -> None:
         """Load existing index from disk. Silently does nothing if not present.
@@ -2154,6 +2244,10 @@ class ASTIndexer:
                     return
             except (OSError, json.JSONDecodeError):
                 pass  # manifest absent or unreadable — proceed normally
+
+        # Clear scratch files stranded by a hard kill mid-write (COGNIREPO-D13).
+        self._sweep_stale_tmp(_ast_index_file())
+        self._sweep_stale_tmp(_ast_meta_file())
 
         if os.path.exists(_ast_index_file()):
             loaded = self._load_json_self_heal(_ast_index_file(), None)

--- a/intelligence/indexer/file_watcher.py
+++ b/intelligence/indexer/file_watcher.py
@@ -73,6 +73,12 @@ class RepoFileHandler(FileSystemEventHandler):
         self._lock = threading.Lock()
         self._pending: dict[str, str] = {}  # abs_path -> "reindex" | "remove"
         self._timer: threading.Timer | None = None
+        # Serializes the *body* of flush(). self._lock only guards _pending /
+        # _timer and is released before the expensive index+save section, so
+        # two Timer threads could previously run that section concurrently and
+        # mutate shared indexer.index_data / graph.G unsynchronized.
+        # See COGNIREPO-D15 and the note in flush().
+        self._flush_lock = threading.RLock()
 
     def _load_debounce_ms(self) -> int:
         """Read indexing.debounce_ms from this repo's config.json (default 500)."""
@@ -117,10 +123,13 @@ class RepoFileHandler(FileSystemEventHandler):
     def _queue(self, action: str, abs_path: str) -> None:
         if self.debounce_ms <= 0:
             # Disabled: process this single event immediately (pre-debounce behavior).
-            if action == "reindex":
-                self._reindex(abs_path)
-            else:
-                self._remove(abs_path)
+            # Still takes _flush_lock so a shutdown flush() can never overlap
+            # with a synchronous save on the emitter thread (COGNIREPO-D15).
+            with self._flush_lock:
+                if action == "reindex":
+                    self._reindex(abs_path)
+                else:
+                    self._remove(abs_path)
             return
         with self._lock:
             self._pending[abs_path] = action  # last action for a path wins; dedupes bursts
@@ -136,7 +145,20 @@ class RepoFileHandler(FileSystemEventHandler):
         graph.save() + invalidate_hybrid_cache() for the whole batch, not per
         event. Called by the debounce timer, and by stop_watching() on
         shutdown so no queued events are lost.
+
+        Serialized by self._flush_lock. threading.Timer.cancel() in _queue()
+        is a no-op once the timer has already fired, so under a burst that
+        outlasts the debounce window (5 saves over ~1 s at debounce_ms=500,
+        with each editor save emitting several modify events) a second timer
+        is scheduled while the first flush is still inside the seconds-long
+        index+save section. Both threads then hit ASTIndexer.save() at once.
+        See COGNIREPO-D15.
         """
+        with self._flush_lock:
+            self._flush_locked()
+
+    def _flush_locked(self) -> None:
+        """flush() body — callers must hold self._flush_lock."""
         with self._lock:
             pending = self._pending
             self._pending = {}
@@ -177,12 +199,33 @@ class RepoFileHandler(FileSystemEventHandler):
         self.indexer.index_data["total_symbols"] = sum(
             len(f.get("symbols", [])) for f in self.indexer.index_data["files"].values()
         )
-        self.indexer.save()
-        self.graph.save()
-        self._write_last_watcher_reindex(reindexed_rel_paths, removed_rel_paths)
+        # Persist + notify. Each step is independently guarded: previously
+        # indexer.save() sat outside any handler, so a raise from it skipped
+        # graph.save(), the D12 audit trail, episodic mark_stale(), AND
+        # invalidate_hybrid_cache() — leaving the graph, the index and the
+        # retrieval cache mutually inconsistent with no record that a batch
+        # was ever attempted. That is precisely the cross-store divergence
+        # E2E-100-1 exists to detect. See COGNIREPO-D15.
+        save_error: str | None = None
+        try:
+            self.indexer.save()
+        except Exception as exc:  # pylint: disable=broad-except
+            save_error = f"indexer.save failed: {exc}"
+            print(f"[watcher] {save_error}")
+
+        try:
+            self.graph.save()
+        except Exception as exc:  # pylint: disable=broad-except
+            save_error = f"{save_error + '; ' if save_error else ''}graph.save failed: {exc}"
+            print(f"[watcher] graph.save failed: {exc}")
+
+        self._write_last_watcher_reindex(reindexed_rel_paths, removed_rel_paths, error=save_error)
 
         if any_reindexed:
-            self.behaviour.save()
+            try:
+                self.behaviour.save()
+            except Exception as exc:  # pylint: disable=broad-except
+                print(f"[watcher] behaviour.save failed: {exc}")
 
         for rel_path in removed_rel_paths:
             try:
@@ -192,6 +235,8 @@ class RepoFileHandler(FileSystemEventHandler):
                 import logging as _logging  # pylint: disable=import-outside-toplevel
                 _logging.getLogger(__name__).warning("episodic mark_stale failed for %s: %s", rel_path, _exc)
 
+        # Must run even when a save failed: the in-memory stores were already
+        # mutated, so a surviving TTL cache entry would serve pre-edit results.
         if any_reindexed or removed_rel_paths:
             try:
                 from intelligence.retrieval.hybrid import invalidate_hybrid_cache  # pylint: disable=import-outside-toplevel
@@ -202,7 +247,9 @@ class RepoFileHandler(FileSystemEventHandler):
         for rel_path in removed_rel_paths:
             print(f"[watcher] removed {rel_path} from index")
 
-    def _write_last_watcher_reindex(self, reindexed: list[str], removed: list[str]) -> None:
+    def _write_last_watcher_reindex(
+        self, reindexed: list[str], removed: list[str], error: str | None = None,
+    ) -> None:
         """
         Overwrite `.cognirepo/index/last_watcher_reindex.json` with this batch's
         activity — a durable, mode-independent trail of watcher-driven reindex
@@ -219,6 +266,10 @@ class RepoFileHandler(FileSystemEventHandler):
                 "session_id": self.session_id,
                 "reindexed": reindexed,
                 "removed": removed,
+                # None on a clean batch; a message when a persist step failed,
+                # so a partially-applied batch is visible to `doctor` and to
+                # anyone reading the trail, instead of looking like a success.
+                "error": error,
             }
             path = os.path.join(get_cognirepo_dir_for_repo(self.repo_root), "index", "last_watcher_reindex.json")
             os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -167,21 +167,47 @@ def _index_is_stale() -> bool | None:
 
 
 def _watcher_alive() -> bool:
-    """True only if watcher.pid exists AND the process is actually running.
+    """True if a watcher process is currently running for this repo.
 
-    A dead watcher's leftover PID file used to permanently suppress
-    staleness detection.
+    Reads the heartbeat file (.cognirepo/watchers/heartbeat), which
+    run_watcher_with_crash_guard() refreshes every 30 s for BOTH the
+    `cognirepo watch` daemon and the in-process auto-watcher that `serve`
+    starts. Falls back to the per-PID registry.
+
+    This previously read `.cognirepo/watcher.pid` — a path nothing in the
+    codebase has ever written (the daemon registers under
+    .cognirepo/watchers/<pid>.json via daemon._pid_file). The function
+    therefore always returned False, which silently disabled the
+    "a live watcher means the index is not stale" guard in graph_stats and
+    let it spawn a competing `index-repo --changed-only` process against a
+    repo an active watcher was already writing. See COGNIREPO-D16.
     """
     try:
-        from core.config.paths import get_path as _gp  # pylint: disable=import-outside-toplevel
-        pid_file = _gp("watcher.pid")
-        if not os.path.exists(pid_file):
-            return False
-        with open(pid_file, encoding="utf-8") as _f:
-            pid = int(_f.read().strip())
-        os.kill(pid, 0)  # signal 0 = existence check
-        return True
-    except (OSError, ValueError):
+        from interface.cli.daemon import (  # pylint: disable=import-outside-toplevel
+            _HEARTBEAT_STALE_THRESHOLD,
+            _is_alive,
+            is_watcher_running_for_path,
+            read_heartbeat,
+        )
+
+        hb = read_heartbeat()
+        if hb:
+            pid = int(hb.get("pid", -1))
+            if _is_alive(pid):
+                import datetime as _dt  # pylint: disable=import-outside-toplevel
+                raw = str(hb.get("timestamp", "")).rstrip("Z")
+                # write_heartbeat() stamps a naive UTC isoformat + "Z".
+                beat = _dt.datetime.fromisoformat(raw).replace(tzinfo=_dt.timezone.utc)
+                age = (_dt.datetime.now(_dt.timezone.utc) - beat).total_seconds()
+                if age < _HEARTBEAT_STALE_THRESHOLD:
+                    return True
+
+        # Heartbeat missing/stale — fall back to the PID registry, which also
+        # prunes dead entries as a side effect.
+        from core.config.paths import get_cognirepo_dir  # pylint: disable=import-outside-toplevel
+        repo_root = os.path.dirname(os.path.abspath(get_cognirepo_dir()))
+        return is_watcher_running_for_path(repo_root) is not None
+    except Exception:  # pylint: disable=broad-except
         return False
 
 
@@ -1500,20 +1526,32 @@ def graph_stats(repo_path: str | None = None) -> dict:
         ]
         top_concepts = sorted(concept_nodes, key=g.G.degree, reverse=True)[:5]
         last_indexed = None
+        full_indexed_at = None
         index_age_minutes = None
         index_stale = None
+        # Resolved inside _repo_ctx so a repo_path-scoped call reads THAT
+        # repo's heartbeat, not the server's default .cognirepo dir.
+        watcher_alive = _watcher_alive()
         from core.config.paths import get_path  # pylint: disable=import-outside-toplevel
         ast_index_path = get_path("index/ast_index.json")
         if os.path.exists(ast_index_path):
             with open(ast_index_path, encoding="utf-8") as f:
-                last_indexed = json.load(f).get("indexed_at")
+                _idx = json.load(f)
+            # `indexed_at` is now stamped by every ASTIndexer.save(), so it
+            # tracks the same event as index_age_minutes (the file mtime).
+            # Before COGNIREPO-D14 it only moved on a full index_repo(), so
+            # this dict could report last_indexed="2h ago" alongside
+            # index_age_minutes=0 — two clocks in one payload.
+            # `full_indexed_at` carries the last complete sweep separately.
+            last_indexed = _idx.get("indexed_at")
+            full_indexed_at = _idx.get("full_indexed_at")
             try:
                 import datetime as _dt  # pylint: disable=import-outside-toplevel
                 mtime = os.path.getmtime(ast_index_path)
                 age_s = time.time() - mtime
                 index_age_minutes = int(age_s // 60)
                 # Stale if >60 min old; only a LIVE watcher suppresses staleness
-                index_stale = index_age_minutes > 60 and not _watcher_alive()
+                index_stale = index_age_minutes > 60 and not watcher_alive
                 # Age says stale, but if git HEAD still matches the last
                 # indexed SHA the CONTENT is current — reporting stale + not
                 # triggering a reindex read as contradictory to agents.
@@ -1537,9 +1575,11 @@ def graph_stats(repo_path: str | None = None) -> dict:
         "edge_count": stats["edges"],
         "top_concepts": top_concepts,
         "last_indexed": last_indexed,
+        "full_indexed_at": full_indexed_at,
         "index_age_minutes": index_age_minutes,
         "index_stale": index_stale,
         "stale_reindexing_triggered": stale_reindexing_triggered,
+        "watcher_alive": watcher_alive,
     }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ proto-plus==1.27.2
 protobuf==5.29.6
 psutil==7.2.2
 py_rust_stemmers==0.1.5
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1_modules==0.4.2
 pybase64==1.4.3
 pycparser==3.0

--- a/tests/test_index_write_concurrency.py
+++ b/tests/test_index_write_concurrency.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_index_write_concurrency.py — COGNIREPO-D13/D14/D15/D16 regression tests.
+
+Found by E2E-100-1 (epic ReliabilityGate-100): a burst-save against a live
+watcher crashed two timer threads inside
+ASTIndexer._atomic_json_dump -> os.replace(ast_index.json.tmp).
+
+The pre-existing tests/test_watcher_debounce.py could not catch this: it
+mocks indexer.save with a MagicMock, so the real writer is never exercised,
+and every case asserts the debounce *collapse* property rather than
+constructing overlapping flushes. These tests drive the real writer.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+
+import pytest
+
+
+# ── D13: concurrent writers must not corrupt or crash ────────────────────────
+
+class TestAtomicJsonDump:
+    """_atomic_json_dump must be safe for N concurrent writers on one path."""
+
+    def test_tmp_path_is_unique_per_writer(self, tmp_path):
+        """The scratch filename must not be a pure function of the target path.
+
+        A shared `path + '.tmp'` is the root cause of both observed failures:
+        the loser of the rename race raises FileNotFoundError, and an
+        interleaved open(tmp, 'w') truncates a file another writer is
+        mid-dump into, promoting partial JSON into place.
+        """
+        from intelligence.indexer.ast_indexer import ASTIndexer
+
+        target = str(tmp_path / "ast_index.json")
+        seen: list[str] = []
+        real_mkstemp = __import__("tempfile").mkstemp
+
+        def _spy(*args, **kwargs):
+            fd, name = real_mkstemp(*args, **kwargs)
+            seen.append(name)
+            return fd, name
+
+        import intelligence.indexer.ast_indexer as mod
+        mod.tempfile.mkstemp = _spy
+        try:
+            ASTIndexer._atomic_json_dump({"a": 1}, target)
+            ASTIndexer._atomic_json_dump({"a": 2}, target)
+        finally:
+            mod.tempfile.mkstemp = real_mkstemp
+
+        assert len(seen) == 2
+        assert seen[0] != seen[1], "two writes reused the same scratch file"
+        assert target + ".tmp" not in seen, "still using the deterministic tmp name"
+
+    def test_concurrent_writers_leave_valid_json(self, tmp_path):
+        """16 threads hammering one path: no exception, and the result parses.
+
+        This is the direct regression for the E2E-100-1 crash.
+        """
+        from intelligence.indexer.ast_indexer import ASTIndexer
+
+        target = str(tmp_path / "ast_index.json")
+        # Large enough that a dump spans multiple write() syscalls, so an
+        # interleaved truncation would actually be observable.
+        payloads = [{"writer": i, "symbols": [f"sym_{i}_{n}" for n in range(2000)]}
+                    for i in range(16)]
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(len(payloads))
+
+        def _write(p):
+            try:
+                barrier.wait()
+                ASTIndexer._atomic_json_dump(p, target)
+            except BaseException as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_write, args=(p,)) for p in payloads]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"concurrent writers raised: {errors!r}"
+
+        with open(target, encoding="utf-8") as f:
+            loaded = json.load(f)  # would raise on a truncated promote
+        # Whichever writer won, its payload must be intact — not spliced.
+        assert loaded["symbols"] == [f"sym_{loaded['writer']}_{n}" for n in range(2000)]
+
+    def test_no_orphaned_tmp_files_after_concurrent_writes(self, tmp_path):
+        """Scratch files must never survive a completed write."""
+        from intelligence.indexer.ast_indexer import ASTIndexer
+
+        target = str(tmp_path / "ast_index.json")
+        errors: list[BaseException] = []
+
+        def _write(i):
+            try:
+                ASTIndexer._atomic_json_dump({"i": i}, target)
+            except BaseException as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_write, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Assert on the collected exceptions too: a thread that dies inside
+        # os.replace() still leaves the directory tidy, so a leftovers-only
+        # check would pass against the very bug this file exists to catch.
+        assert not errors, f"concurrent writers raised: {errors!r}"
+        leftovers = [n for n in os.listdir(tmp_path) if n.endswith(".tmp")]
+        assert leftovers == [], f"orphaned scratch files: {leftovers}"
+
+    def test_tmp_removed_when_serialization_fails(self, tmp_path):
+        """A raise mid-dump must not strand a scratch file."""
+        from intelligence.indexer.ast_indexer import ASTIndexer
+
+        target = str(tmp_path / "ast_index.json")
+
+        class _Unserializable:
+            pass
+
+        with pytest.raises(TypeError):
+            ASTIndexer._atomic_json_dump({"bad": _Unserializable()}, target)
+
+        assert [n for n in os.listdir(tmp_path) if n.endswith(".tmp")] == []
+        assert not os.path.exists(target), "failed write must not create the target"
+
+    def test_sweep_removes_legacy_and_orphaned_tmp(self, tmp_path):
+        """load() clears scratch files stranded by a SIGKILL mid-write."""
+        from intelligence.indexer.ast_indexer import ASTIndexer
+
+        target = str(tmp_path / "ast_index.json")
+        (tmp_path / "ast_index.json").write_text("{}")
+        (tmp_path / "ast_index.json.tmp").write_text("partial")          # legacy fixed name
+        (tmp_path / "ast_index.json.abc123.tmp").write_text("partial")   # mkstemp orphan
+        (tmp_path / "keep.json").write_text("{}")
+
+        ASTIndexer._sweep_stale_tmp(target)
+
+        remaining = set(os.listdir(tmp_path))
+        assert "ast_index.json.tmp" not in remaining
+        assert "ast_index.json.abc123.tmp" not in remaining
+        # The real index and unrelated files must survive the sweep.
+        assert {"ast_index.json", "keep.json"} <= remaining
+
+
+# ── D14: indexed_at must track every save, not only full index_repo runs ─────
+
+class TestIndexedAtFreshness:
+    def test_save_stamps_indexed_at(self, tmp_path, monkeypatch):
+        """The watcher's incremental save must advance indexed_at.
+
+        Previously only index_repo() stamped it, so graph_stats reported a
+        two-hour-old last_indexed next to index_age_minutes=0.
+        """
+        import intelligence.indexer.ast_indexer as mod
+
+        monkeypatch.setenv("COGNIREPO_DIR", str(tmp_path / ".cognirepo"))
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+
+        idx = mod.ASTIndexer.__new__(mod.ASTIndexer)
+        idx.index_data = {"files": {}, "reverse_index": {}, "repo_root": str(tmp_path)}
+        idx.faiss_index = None
+        idx.faiss_meta = []
+
+        monkeypatch.setattr(mod, "_write_manifest", lambda **_kw: None)
+        monkeypatch.setattr(mod, "_now", lambda: "2026-07-22T10:00:00+00:00")
+        idx.save()
+        assert idx.index_data["indexed_at"] == "2026-07-22T10:00:00+00:00"
+
+        monkeypatch.setattr(mod, "_now", lambda: "2026-07-22T12:30:00+00:00")
+        idx.save()
+        assert idx.index_data["indexed_at"] == "2026-07-22T12:30:00+00:00", \
+            "incremental save left indexed_at frozen"
+
+    def test_save_preserves_full_indexed_at(self, tmp_path, monkeypatch):
+        """full_indexed_at marks the last COMPLETE sweep and must not move on save()."""
+        import intelligence.indexer.ast_indexer as mod
+
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+
+        idx = mod.ASTIndexer.__new__(mod.ASTIndexer)
+        idx.index_data = {
+            "files": {}, "reverse_index": {}, "repo_root": str(tmp_path),
+            "full_indexed_at": "2026-07-22T08:00:00+00:00",
+        }
+        idx.faiss_index = None
+        idx.faiss_meta = []
+
+        monkeypatch.setattr(mod, "_write_manifest", lambda **_kw: None)
+        monkeypatch.setattr(mod, "_now", lambda: "2026-07-22T12:30:00+00:00")
+        idx.save()
+
+        assert idx.index_data["full_indexed_at"] == "2026-07-22T08:00:00+00:00"
+        assert idx.index_data["indexed_at"] == "2026-07-22T12:30:00+00:00"
+
+
+# ── D15: flush() serialization + partial-failure containment ─────────────────
+
+def _make_handler(tmp_path, debounce_ms):
+    """Mirrors tests/test_watcher_debounce.py::_make_handler."""
+    from unittest.mock import MagicMock
+    from intelligence.indexer.file_watcher import RepoFileHandler
+    from data.graph.knowledge_graph import KnowledgeGraph
+    import networkx as nx
+
+    kg = KnowledgeGraph.__new__(KnowledgeGraph)
+    kg.G = nx.DiGraph()
+    kg.nodes_for_file = MagicMock(return_value=[])
+    kg.remove_node_edges = MagicMock()
+    kg.remove_file_nodes = MagicMock()
+    kg.save = MagicMock()
+
+    indexer = MagicMock()
+    indexer.faiss_index = None
+    indexer.index_data = {"files": {}, "reverse_index": {}}
+    indexer.index_file = MagicMock(return_value={"symbols": []})
+    indexer._build_reverse_index = MagicMock()
+    indexer._resolve_call_stubs = MagicMock()
+    indexer.save = MagicMock()
+
+    handler = RepoFileHandler(
+        repo_root=str(tmp_path), indexer=indexer, graph=kg,
+        behaviour=MagicMock(), session_id="test", debounce_ms=debounce_ms,
+    )
+    return handler, indexer, kg
+
+
+class TestFlushSerialization:
+    def test_concurrent_flushes_never_overlap(self, tmp_path):
+        """Two threads calling flush() must not run the batch body concurrently.
+
+        Timer.cancel() is a no-op once the timer has fired, so a burst that
+        outlasts the debounce window really does schedule a second flush
+        while the first is still inside the seconds-long index+save section.
+        """
+        handler, indexer, _ = _make_handler(tmp_path, debounce_ms=5000)
+
+        concurrent = []
+        active = {"n": 0}
+        gate = threading.Lock()
+
+        def _slow_save():
+            with gate:
+                active["n"] += 1
+                if active["n"] > 1:
+                    concurrent.append(True)
+            # Wide window for another thread to enter the body.
+            threading.Event().wait(0.15)
+            with gate:
+                active["n"] -= 1
+
+        indexer.save.side_effect = _slow_save
+
+        # Each thread must queue its OWN event before flushing. A plain
+        # "6 threads all call flush()" does not reproduce the race: the first
+        # arrival drains _pending and the other five hit the `if not pending:
+        # return` fast path, so only one thread ever reaches the save section.
+        # The real sequence is a burst that keeps producing events while an
+        # earlier flush is still inside index+save.
+        def _queue_then_flush(i):
+            f = tmp_path / f"mod_{i}.py"
+            f.write_text("def f(): pass")
+            handler._queue("reindex", str(f))
+            handler.flush()
+
+        threads = []
+        for i in range(6):
+            t = threading.Thread(target=_queue_then_flush, args=(i,))
+            t.start()
+            threads.append(t)
+            threading.Event().wait(0.02)  # stagger inside the slow save window
+        for t in threads:
+            t.join()
+
+        assert not concurrent, "two flush() threads entered the batch body at once"
+
+    def test_indexer_save_failure_does_not_skip_remaining_steps(self, tmp_path):
+        """A raise from indexer.save() must not abandon the rest of the batch.
+
+        Previously indexer.save() sat outside any handler, so a failure
+        skipped graph.save(), the D12 audit trail, and the hybrid-cache
+        invalidation — leaving the stores diverged with no record.
+        """
+        from watchdog.events import FileModifiedEvent
+        import intelligence.retrieval.hybrid as hybrid
+
+        handler, indexer, kg = _make_handler(tmp_path, debounce_ms=5000)
+        indexer.save.side_effect = FileNotFoundError("ast_index.json.tmp")
+
+        invalidated = {"n": 0}
+        original = hybrid.invalidate_hybrid_cache
+        hybrid.invalidate_hybrid_cache = lambda: invalidated.__setitem__("n", invalidated["n"] + 1)
+
+        written = {}
+        handler._write_last_watcher_reindex = (
+            lambda reindexed, removed, error=None: written.update(
+                reindexed=reindexed, removed=removed, error=error)
+        )
+
+        try:
+            f = tmp_path / "auth.py"
+            f.write_text("def verify_token(): pass")
+            handler.on_modified(FileModifiedEvent(str(f)))
+            handler.flush()  # must not raise
+        finally:
+            hybrid.invalidate_hybrid_cache = original
+
+        kg.save.assert_called_once()
+        assert invalidated["n"] == 1, "hybrid cache left holding pre-edit results"
+        assert written.get("error"), "partial batch recorded as a clean success"
+        assert "auth.py" in written["reindexed"]
+
+
+# ── D16: watcher liveness must read a file something actually writes ─────────
+
+class TestWatcherAlive:
+    def test_reads_heartbeat_not_phantom_pid_file(self, tmp_path, monkeypatch):
+        """_watcher_alive() must not depend on .cognirepo/watcher.pid.
+
+        Nothing in the codebase has ever written that path — the daemon
+        registers under .cognirepo/watchers/. The old implementation was
+        therefore hardwired to False.
+        """
+        import json as _json
+        import interface.cli.daemon as daemon
+        from interface.server.mcp_server import _watcher_alive
+
+        watchers = tmp_path / ".cognirepo" / "watchers"
+        watchers.mkdir(parents=True)
+        monkeypatch.setattr(daemon, "_watchers_dir", lambda: watchers)
+
+        assert _watcher_alive() is False  # nothing running
+
+        import datetime as _dt
+        (watchers / "heartbeat").write_text(_json.dumps({
+            "pid": os.getpid(),
+            "path": str(tmp_path),
+            "timestamp": _dt.datetime.utcnow().isoformat() + "Z",
+        }))
+        assert _watcher_alive() is True, "live heartbeat not detected"
+
+    def test_stale_heartbeat_is_not_alive(self, tmp_path, monkeypatch):
+        """A heartbeat older than the staleness threshold must not count as live."""
+        import json as _json
+        import datetime as _dt
+        import interface.cli.daemon as daemon
+        from interface.server.mcp_server import _watcher_alive
+
+        watchers = tmp_path / ".cognirepo" / "watchers"
+        watchers.mkdir(parents=True)
+        monkeypatch.setattr(daemon, "_watchers_dir", lambda: watchers)
+
+        old = _dt.datetime.utcnow() - _dt.timedelta(seconds=daemon._HEARTBEAT_STALE_THRESHOLD + 60)
+        (watchers / "heartbeat").write_text(_json.dumps({
+            "pid": os.getpid(), "path": str(tmp_path), "timestamp": old.isoformat() + "Z",
+        }))
+
+        assert _watcher_alive() is False


### PR DESCRIPTION
Root-cause fixes for **E2E-100-1** (epic ReliabilityGate-100), which crashed two watcher threads on `os.replace(ast_index.json.tmp → ast_index.json)` during a burst-save and reported a 2-hour-stale `last_indexed`.

## The defects

### D13 (P0) — concurrent index writes could crash the watcher *or silently promote truncated JSON*

`ASTIndexer._atomic_json_dump()` derived its scratch filename from the target path, so every concurrent writer shared one `ast_index.json.tmp`:

- two watcher flush threads (D15),
- a second `cognirepo serve`,
- the background `index-repo --changed-only` that `graph_stats` spawns (D16).

Two failure modes, and **the one logged in the test run is the benign one**:

1. **loud** — the loser of the rename race raises `FileNotFoundError`;
2. **silent** — an interleaved `open(tmp,"w")` truncates the file another writer is mid-`json.dump()` into, and that partial JSON is then `os.replace()`d into place. This is the *"parse error at char 73M on a large-monorepo ast_index.json"* the original atomic-write commit was written to fix. It narrowed the window without closing it.

Fix: scratch files come from `tempfile.mkstemp()` (unique per writer) and are unlinked if the write fails. `ASTIndexer.save()` additionally holds `store_lock()` across the whole four-file group (`ast_index.json`, `ast.index`, `ast_metadata.json`, `manifest.json`) — per-file atomic renames alone still let two processes interleave and leave `manifest.json`'s checksums describing a different index than the one on disk, so `verify-index` would report corruption that never happened. **`KnowledgeGraph.save()` has always taken this lock; `ASTIndexer.save()` did not** — same defect class, one hardened, one overlooked. `load()` now sweeps scratch files stranded by a hard kill, including the legacy fixed name.

### D14 (P1) — `graph_stats` reported two clocks in one payload

`indexed_at` is stamped at `ast_indexer.py::index_repo` only, never by `save()`, so the watcher's incremental path left it frozen while `_write_manifest()` stamped `_now()` on every save — the observed 16:31:07 vs 18:20:10 gap. Worse, `graph_stats` returned `last_indexed` (last *full* index) next to `index_age_minutes` (file mtime) in the same dict, so an agent saw *"last indexed 2h ago"* and *"index age 0 minutes"* simultaneously.

Fix: stamp `indexed_at` on every `save()`; new `full_indexed_at` carries the last complete sweep separately. `graph_stats` returns both, plus `watcher_alive`.

### D15 (P0) — overlapping flushes; a failed save abandoned the batch

`flush()` held `self._lock` only while draining `_pending`, releasing it before the seconds-long index+save section. `threading.Timer.cancel()` is a no-op once the timer has fired, so a burst outlasting the debounce window really does schedule a second flush while the first is still running:

```
t=0     burst → timer T1 @500ms
t=540   T1 fires → flush#1 drains, releases lock, begins index+save (seconds)
t=600   more events → T2 @1100ms  (cancel() is a no-op, T1 already fired)
t=1100  T2 fires → flush#2 runs concurrently with flush#1
```

Both threads then mutated shared `indexer.index_data` / `graph.G` unsynchronized and called `save()` at once. Fix: `flush()` is serialized by a dedicated lock, as is the `debounce_ms=0` synchronous path.

Separately, `indexer.save()` sat **outside any handler**, so a raise from it skipped `graph.save()`, the D12 audit trail, episodic `mark_stale()`, and `invalidate_hybrid_cache()` — producing exactly the cross-store divergence E2E-100-1 exists to detect, with no trace in `last_watcher_reindex.json`. Each step is now independently guarded, and the audit record gained an `error` field so a partially-applied batch is no longer indistinguishable from a clean one.

### D16 (P1, latent) — `_watcher_alive()` was hardwired to `False`

It read `.cognirepo/watcher.pid` — **a path nothing in the codebase has ever written**; the daemon registers under `.cognirepo/watchers/<pid>.json` via `daemon._pid_file`. So `index_stale = index_age_minutes > 60 and not _watcher_alive()` degraded to the age check alone, and `graph_stats` could spawn a competing `index-repo --changed-only` against a repo an active watcher was already writing — a third concurrent writer feeding D13. Did not fire in the test run only because `index_age_minutes ≈ 0`.

Fix: read the heartbeat that `run_watcher_with_crash_guard()` refreshes every 30 s for **both** the `cognirepo watch` daemon and the in-process auto-watcher `serve` starts, with the PID registry as fallback.

## Tests

New `tests/test_index_write_concurrency.py` — 11 tests that drive the **real** writer.

**10 of the 11 fail against the pre-fix code**, reproducing the logged crash verbatim:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../ast_index.json.tmp' -> '.../ast_index.json'
```

The existing `tests/test_watcher_debounce.py` could not have caught any of this: it mocks `indexer.save` with a `MagicMock`, so no watcher test ever reached the real writer, and every case asserts the debounce *collapse* property rather than constructing overlapping flushes.

Full suite: **1272 passed, 5 skipped**.

Live verification on a scratch repo with a real watcher daemon attached — 10 burst-saves across 2 files:

| Check | Result |
|---|---|
| Reindex batches for the burst | 1 (correctly collapsed) |
| Watcher thread crashes | 0 |
| Orphaned `*.tmp` files | 0 |
| `last_watcher_reindex.json` | `"error": null` |
| `indexed_at` vs `manifest.indexed_at` | agree to sub-second (was a 2 h gap) |
| `full_indexed_at` | correctly earlier than `last_indexed` |
| `_watcher_alive()` | `True` (was always `False`) |

## Also in this PR

Records the **corrected E2E-100-2 root cause** in the epic test suite. That failure is environment/config, not the client-staleness bug originally hypothesised:

`.mcp.json` registers the server at *project* scope, which Claude Code gates behind a one-time approval recorded in `~/.claude.json → enabledMcpjsonServers`. That list (and `disabledMcpjsonServers`) is **empty** — never approved, so the server is never loaded into a session. `claude mcp list` bypasses the gate entirely (it spawns the process itself for a health check), which is why it prints `✔ Connected` next to a session exposing zero tools. A timed raw stdio handshake returns `initialize` and `tools/list` at 0.55 s with 34 tools, ruling out a startup timeout.

The assertion that test actually owns — artifact/spec parity — **passed 5/5 at 34/34**. Only the client-reconnect step failed, for a reason unrelated to the epic. Retest needed after `claude mcp reset-project-choices`, and the test's prerequisites should assert the approval state so an unapproved config fails as a setup error rather than masquerading as tool-discovery drift.

Also filed as a test-suite defect: E2E-100-1's *"doctor green apart from the intentional dirty warning"* is unachievable in an environment with no API keys and incomplete doc coverage, and cannot distinguish a regression from ambient noise. It should be a delta assertion against a pre-mutation baseline.

## Follow-ups (not in this PR)

- `watch --ensure-running` does not supervise a killed `serve` process (already noted under E2E-100-3).
- Observed while cleaning up the scratch repo: the daemonized watcher did not exit on `SIGTERM` and needed `SIGKILL`, despite `_start_watcher` installing a `SIGTERM` handler. Worth a separate look — the handler is installed in the parent, and the daemonized grandchild may not inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
