### PR TITLE
COGNIREPO-201: graph integrity sweep + metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [Unreleased]
+
+### Added
+- **COGNIREPO-201 — knowledge graph integrity sweep + metrics.**
+  `KnowledgeGraph.integrity_report(repo_root)` reports `orphans` (FILE/FUNCTION/CLASS
+  nodes with degree 0 — restricted to these types since MEMORY/SESSION/ERROR/QUERY/
+  CONCEPT nodes are legitimately edge-free early in their lifecycle) and
+  `dangling_files` (file paths no longer on disk, deduplicated across every symbol
+  in that file), O(nodes). `graph_stats` gains an output-only `integrity` block (no
+  input-schema change); `doctor` flags nonzero orphans/dangling as a warning with a
+  repair hint. New `cognirepo graph repair [--apply]` prunes dangling file nodes via
+  `remove_file_nodes()` — dry-run by default, orphan CONCEPT stubs untouched (they
+  carry no `file` attr).
+
 ## [2.0.1] — 2026-07-31
 
 ### Fixed

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
@@ -8,5 +8,16 @@
   repair and re-check."
 - Expected results: integrity shows dangling ≥ 1 naming pattern; doctor flags it;
   `cognirepo graph repair --apply` prunes; re-run shows 0; other nodes untouched.
-- Obtained results:
-- Verdict:
+- Obtained results: Automated-equivalent coverage added and passing (unit-level, real
+  KnowledgeGraph, no mocks): `tests/test_graph.py::TestKnowledgeGraphIntegrity` (clean graph →
+  0/0; orphan restricted to FILE/FUNCTION/CLASS; dangling file detected + deduped across its
+  symbols; `--apply`-equivalent prune removes danglers only, orphan CONCEPT untouched, re-sweep
+  shows 0), `tests/test_doctor.py::TestDoctorGraphIntegrity` (seeded dangling node → doctor WARN
+  with repair hint + exit ≥1; clean graph → "0 orphans · 0 dangling files"),
+  `tests/test_graph_repair.py::TestGraphRepair` (dry-run reports without mutating; `--apply`
+  removes exactly the dangling nodes and prints the count; clean graph reports "no dangling
+  file nodes found"). Full suite: 1322 passed, 5 skipped.
+  Live MCP verification against `cognirepo_test_repo/easy` (per skill.md step 4) — left for
+  the user: restart server after `rm`-ing an indexed file with the watcher stopped, run
+  `graph_stats`/doctor/`graph repair --apply` through the MCP client itself.
+- Verdict: PASS (automated). Live retest pending.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
@@ -17,7 +17,19 @@
   `tests/test_graph_repair.py::TestGraphRepair` (dry-run reports without mutating; `--apply`
   removes exactly the dangling nodes and prints the count; clean graph reports "no dangling
   file nodes found"). Full suite: 1322 passed, 5 skipped.
-  Live MCP verification against `cognirepo_test_repo/easy` (per skill.md step 4) — left for
-  the user: restart server after `rm`-ing an indexed file with the watcher stopped, run
-  `graph_stats`/doctor/`graph repair --apply` through the MCP client itself.
-- Verdict: PASS (automated). Live retest pending.
+  Live retest against `cognirepo_test_repo/easy/fastapi` (indexed, watcher confirmed not
+  running — `cognirepo list` showed no running watcher daemons) — executed 2026-08-06 via CLI
+  equivalents of the MCP tools (`graph-stats`/`doctor`/`graph repair`, same
+  `KnowledgeGraph.integrity_report()` code path graph_stats calls): baseline
+  `graph-stats`/`doctor` on the indexed repo showed 0 orphans/0 dangling (7153 nodes, 28614
+  edges). Removed `fastapi/security/utils.py` (1 indexed FUNCTION,
+  `get_authorization_scheme_param`). Re-ran `graph-stats` →
+  `integrity.dangling_files: ["fastapi/security/utils.py"]`, orphans still `[]`. `doctor` → WARN
+  "0 orphan node(s), 1 dangling file(s)" with the `cognirepo graph repair --apply` hint, exit
+  code 1. `cognirepo graph repair` (dry-run) reported the same path without mutating. `cognirepo
+  graph repair --apply` removed 2 nodes (the FILE node + its FUNCTION) across the 1 dangling
+  path. Re-ran `graph-stats`/`doctor` → 0 orphans/0 dangling, 7152 nodes/28611 edges (net -1
+  node/-3 edges — consistent with live call edges redirecting onto an unresolved CONCEPT stub
+  per COGNIREPO-D10 rather than being dropped; no other symbols touched). Restored the file via
+  `git checkout -- fastapi/security/utils.py`; working tree clean.
+- Verdict: PASS (automated + live retest).

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -4,9 +4,9 @@ stories:
   - id: COGNIREPO-201
     status: in-review
     branch: story/COGNIREPO-201
-    pr: null
-    test_status: pass  # automated cases pass (1322 passed, 5 skipped); live E2E-100-1-style
-                        # re-verification against cognirepo_test_repo/easy left for the user
+    pr: https://github.com/ashlesh-t/cognirepo/pull/47
+    test_status: pass  # automated (1322 passed, 5 skipped) + live TC-201-1 retest against
+                        # cognirepo_test_repo/easy/fastapi, both PASS
   - id: COGNIREPO-202
     status: not-started
     branch: story/COGNIREPO-202

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -1,11 +1,12 @@
 epic_id: COGNIREPO-200
-status: not-started
+status: in-progress
 stories:
   - id: COGNIREPO-201
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-201
     pr: null
-    test_status: not-run
+    test_status: pass  # automated cases pass (1322 passed, 5 skipped); live E2E-100-1-style
+                        # re-verification against cognirepo_test_repo/easy left for the user
   - id: COGNIREPO-202
     status: not-started
     branch: story/COGNIREPO-202

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,8 +8,8 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: not-started
-    blocked_by: [COGNIREPO-100]
+    status: in-progress  # COGNIREPO-201 in-review
+    blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights
     status: not-started

--- a/data/graph/knowledge_graph.py
+++ b/data/graph/knowledge_graph.py
@@ -483,3 +483,50 @@ class KnowledgeGraph:
             "nodes": self.G.number_of_nodes(),
             "edges": self.G.number_of_edges(),
         }
+
+    # ── integrity ─────────────────────────────────────────────────────────────
+
+    _ORPHAN_TYPES = (NodeType.FILE, NodeType.FUNCTION, NodeType.CLASS)
+
+    def integrity_report(self, repo_root: str) -> dict:
+        """Structural + on-disk integrity sweep. O(nodes) — safe to run on every
+        graph_stats call (AC4: < 1s on a medium repo).
+
+        orphans        : FILE/FUNCTION/CLASS node IDs with degree 0. Restricted to
+                          these types — MEMORY/SESSION/ERROR/QUERY/USER_ACTION/CONCEPT
+                          nodes are legitimately edge-free early in their lifecycle.
+        dangling_files : unique file paths (FILE node IDs, or FUNCTION/CLASS nodes'
+                          'file' attr) that no longer exist under repo_root — left
+                          behind when a file is deleted outside a live watcher/server
+                          (COGNIREPO-100-Discovery §3/§4).
+        swept_at       : ISO-8601 UTC timestamp of this sweep.
+
+        See COGNIREPO-201.
+        """
+        orphans = [
+            n for n, d in self.G.nodes(data=True)
+            if d.get("type") in self._ORPHAN_TYPES and self.G.degree(n) == 0
+        ]
+
+        dangling: list[str] = []
+        checked: set[str] = set()
+        for n, d in self.G.nodes(data=True):
+            ntype = d.get("type")
+            if ntype == NodeType.FILE:
+                rel = n
+            elif ntype in (NodeType.FUNCTION, NodeType.CLASS):
+                rel = d.get("file")
+            else:
+                continue
+            if not rel or rel in checked:
+                continue
+            checked.add(rel)
+            if not os.path.exists(os.path.join(repo_root, rel)):
+                dangling.append(rel)
+
+        from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+        return {
+            "orphans": orphans,
+            "dangling_files": dangling,
+            "swept_at": datetime.now(tz=timezone.utc).isoformat(),
+        }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,7 +20,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 | `log_episode(event, metadata)` | ✅ | `data/memory/episodic_memory.py::log_event()` | Append-only JSONL with timestamp chain |
 | `search_docs(query)` | ✅ | `intelligence/retrieval/docs_search.py` | Full-text search over all `.md` files, returns file+line+snippet |
 | `episodic_search(query, limit)` | ✅ | `data/memory/episodic_memory.py::search_episodes()` | BM25Okapi ranked; module-level corpus cache with TTL |
-| `graph_stats()` | ✅ | `interface/server/mcp_server.py` → `KnowledgeGraph.stats()` | Node count by type, edge count |
+| `graph_stats()` | ✅ | `interface/server/mcp_server.py` → `KnowledgeGraph.stats()` + `integrity_report()` | Node/edge counts, index freshness, integrity (orphans, dangling_files, swept_at) |
 | `semantic_search_code(query, language, top_k)` | ✅ | `interface/tools/semantic_search_code.py` | FAISS search filtered to code-type entries; language filter optional |
 | `dependency_graph(file_path)` | ✅ | `interface/tools/dependency_graph.py` | Returns imports-from + imported-by using knowledge graph edges |
 | `explain_change(file_path, before, after)` | ✅ | `interface/tools/explain_change.py` | Diff analysis using `difflib`; identifies added/removed symbols |
@@ -325,9 +325,9 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-91 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+92 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
-`tests/` for the full list. The 89-file count is pinned against `tests/test_docs_sync.py`,
+`tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.
 
 | Test File | What it Covers |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -202,15 +202,20 @@ freshness.
 **Output:**
 ```json
 {
-  "nodes": 1243,
-  "edges": 4871,
-  "node_types": { "FUNCTION": 892, "CLASS": 201, "FILE": 150 },
-  "healthy": true,
+  "node_count": 1243,
+  "edge_count": 4871,
+  "top_concepts": ["symbol::foo", "symbol::bar"],
   "last_indexed": "2026-07-22T18:20:10+00:00",
   "full_indexed_at": "2026-07-22T16:31:07+00:00",
   "index_age_minutes": 0,
   "index_stale": false,
-  "watcher_alive": true
+  "stale_reindexing_triggered": false,
+  "watcher_alive": true,
+  "integrity": {
+    "orphans": [],
+    "dangling_files": [],
+    "swept_at": "2026-07-31T12:00:00+00:00"
+  }
 }
 ```
 
@@ -227,6 +232,18 @@ freshness.
 Before COGNIREPO-D14, `last_indexed` only advanced on a full `index_repo()`
 run, so a repo kept current by the watcher reported a hours-old
 `last_indexed` next to `index_age_minutes: 0` — two clocks in one payload.
+
+**Integrity fields (COGNIREPO-201):**
+
+| Field | Meaning |
+|---|---|
+| `orphans` | FILE/FUNCTION/CLASS node IDs with degree 0 (no edges in or out). Excludes MEMORY/SESSION/ERROR/QUERY/CONCEPT nodes, which are legitimately edge-free early in their lifecycle. |
+| `dangling_files` | File paths (FILE node IDs, or FUNCTION/CLASS nodes' `file` attr) that no longer exist on disk — left behind when a file is deleted while no watcher/server was running to catch it. |
+| `swept_at` | ISO-8601 UTC timestamp of this integrity sweep — recomputed on every `graph_stats` call, O(nodes). |
+
+`doctor` flags nonzero `orphans`/`dangling_files` as a warning with a repair hint.
+`cognirepo graph repair [--apply]` prunes dangling file nodes (dry-run by default) —
+see [USAGE.md](USAGE.md).
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -172,13 +172,17 @@ cognirepo lookup-symbol Foo --include-org # also search sibling repos in the org
 cognirepo who-calls parse_config          # callers, from the call graph
 cognirepo subgraph interface/cli/main.py  # graph neighbourhood (--depth N)
 cognirepo graph-stats                     # node/edge counts + index freshness
+cognirepo graph repair                    # dry-run: list dangling file nodes
+cognirepo graph repair --apply            # prune them (orphan CONCEPTs untouched)
 cognirepo episodic-search "watcher crash" # keyword search over the event log
 ```
 
 `graph-stats` reports both clocks — `last_indexed` (any save, including the
 watcher's incremental path) and `full_indexed_at` (the last complete sweep) —
 plus `watcher_alive`, so "the index is fresh" and "something is keeping it
-fresh" are separate answers.
+fresh" are separate answers. It also gains an `integrity` block (orphans,
+dangling_files, swept_at) — `doctor` flags nonzero counts; `graph repair`
+prunes danglers (nodes whose file no longer exists on disk).
 
 ---
 

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -276,6 +276,45 @@ def _cmd_verify_index(verbose: bool = False) -> int:
     return 1 if issues else 0
 
 
+def _cmd_graph_repair(apply: bool = False) -> int:
+    """
+    Prune dangling file nodes (and their symbols) from the knowledge graph.
+
+    Dry-run by default — reports what integrity_report() found without
+    mutating the graph. --apply removes them via remove_file_nodes(), which
+    redirects any live call/inherit edges onto an unresolved CONCEPT stub
+    rather than dropping them, and leaves orphan CONCEPT stubs untouched
+    (they carry no 'file' attr, so nodes_for_file() never matches them).
+    See COGNIREPO-201.
+    """
+    # pylint: disable=import-outside-toplevel
+    from data.graph.knowledge_graph import KnowledgeGraph
+
+    kg = KnowledgeGraph()
+    repo_root = os.path.dirname(os.path.abspath(get_path("")))
+    report = kg.integrity_report(repo_root)
+    dangling = report["dangling_files"]
+
+    if not dangling:
+        print("graph repair: no dangling file nodes found.")
+        return 0
+
+    print(f"graph repair: {len(dangling)} dangling file path(s) found:")
+    for f in dangling:
+        print(f"  {f}")
+
+    if not apply:
+        print("\nDry run — no changes made. Re-run with --apply to prune.")
+        return 0
+
+    removed_total = 0
+    for f in dangling:
+        removed_total += len(kg.remove_file_nodes(f))
+    kg.save()
+    print(f"\nRemoved {removed_total} node(s) across {len(dangling)} dangling file path(s).")
+    return 0
+
+
 def _check_working_tree_dirty(manifest: dict) -> list[str]:
     """
     Return the list of indexed source paths with uncommitted working-tree changes.
@@ -517,6 +556,20 @@ def _cmd_doctor(verbose: bool = False, release_check: bool = False, as_json: boo
         if verbose:
             _gpath = get_path("graph/graph.pkl")
             print(f"       {os.path.abspath(_gpath)}")
+
+        # ── Check 3a: Knowledge graph integrity (COGNIREPO-201) ────────────────
+        _repo_root = os.path.dirname(os.path.abspath(get_path("")))
+        _integrity = _kg.integrity_report(_repo_root)
+        _n_orphans = len(_integrity["orphans"])
+        _n_dangling = len(_integrity["dangling_files"])
+        if _n_orphans == 0 and _n_dangling == 0:
+            _ok("Graph integrity — 0 orphans · 0 dangling files")
+        else:
+            _warn(
+                f"Graph integrity — {_n_orphans} orphan node(s), "
+                f"{_n_dangling} dangling file(s)",
+                "Run: cognirepo graph repair --apply",
+            )
     except Exception as exc:  # pylint: disable=broad-except
         _fail(f"Knowledge graph — {exc}", "Run: cognirepo index-repo .")
         issues += 1
@@ -2597,6 +2650,7 @@ def _print_help() -> None:
     _row("who-calls <fn>",    "Trace callers of a function in the call graph")
     _row("subgraph <entity>", "Show knowledge-graph neighbourhood for an entity")
     _row("graph-stats",       "Node/edge count and health of the knowledge graph")
+    _row("graph repair",      "Prune dangling file nodes from the graph (--apply to write)")
 
     # ── AI Query ──────────────────────────────────────────────────────────────
     _hdr("AI QUERY")
@@ -3188,6 +3242,18 @@ def _main():
     p_sub.add_argument("--depth", type=int, default=2)
 
     sub.add_parser("graph-stats", help="Node/edge count and health of the knowledge graph")
+
+    # graph (COGNIREPO-201) — integrity maintenance, separate from graph-stats above
+    p_graph = sub.add_parser("graph", help="Knowledge-graph integrity maintenance")
+    graph_sub = p_graph.add_subparsers(dest="graph_command")
+    p_graph_repair = graph_sub.add_parser(
+        "repair",
+        help="Prune dangling file nodes from the knowledge graph (dry-run by default)",
+    )
+    p_graph_repair.add_argument(
+        "--apply", action="store_true",
+        help="Actually prune (default: dry-run report only)",
+    )
 
     p_mcpset = sub.add_parser("mcp-setup", help="Re-run MCP integration (Claude / Gemini / Cursor)")
     p_mcpset.add_argument("--target", action="append", dest="targets",
@@ -4391,6 +4457,12 @@ def _main():
                 _print_results(_srv.subgraph(args.entity, depth=args.depth))
             else:  # graph-stats
                 _print_results(_srv.graph_stats())
+
+        elif args.command == "graph":
+            if getattr(args, "graph_command", None) == "repair":
+                sys.exit(_cmd_graph_repair(apply=getattr(args, "apply", False)))
+            print("Usage: cognirepo graph repair [--apply]")
+            sys.exit(2)
 
         elif args.command == "mcp-setup":
             from interface.cli.init_project import setup_mcp  # pylint: disable=import-outside-toplevel

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1565,6 +1565,9 @@ def graph_stats(repo_path: str | None = None) -> dict:
         if g is None:
             g = _get_graph()
         stats = g.stats()
+        from core.config.paths import get_cognirepo_dir  # pylint: disable=import-outside-toplevel
+        integrity_root = _root or os.path.dirname(os.path.abspath(get_cognirepo_dir()))
+        integrity = g.integrity_report(integrity_root)
         from data.graph.knowledge_graph import PYTHON_BUILTINS  # pylint: disable=import-outside-toplevel
         concept_nodes = [
             n for n, d in g.G.nodes(data=True)
@@ -1626,6 +1629,7 @@ def graph_stats(repo_path: str | None = None) -> dict:
         "index_stale": index_stale,
         "stale_reindexing_triggered": stale_reindexing_triggered,
         "watcher_alive": watcher_alive,
+        "integrity": integrity,
     }
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -82,6 +82,8 @@ def _run_doctor(
                 return 4218
         class _FakeKG:
             G = _FakeG()
+            def integrity_report(self, repo_root):  # pylint: disable=unused-argument
+                return {"orphans": [], "dangling_files": [], "swept_at": "2026-01-01T00:00:00+00:00"}
         fake_graph_mod.KnowledgeGraph = _FakeKG
     monkeypatch.setitem(sys.modules, "data.graph.knowledge_graph", fake_graph_mod)
 
@@ -334,6 +336,37 @@ class TestDoctorGraphQuarantine:
 
         assert "corrupt-" not in out
         assert code == 0
+
+
+class TestDoctorGraphIntegrity:
+    """COGNIREPO-201 AC2: doctor flags a seeded dangling node; clean fresh index reports 0/0."""
+
+    def test_dangling_node_produces_warn(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_doctor
+
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+        kg.save()
+
+        code = _cmd_doctor(verbose=False)
+        out = capsys.readouterr().out
+        assert "Graph integrity" in out
+        assert "1 dangling file" in out
+        assert "cognirepo graph repair --apply" in out
+        assert code >= 1
+
+    def test_clean_graph_reports_zero(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph
+        from interface.cli.main import _cmd_doctor
+
+        KnowledgeGraph().save()
+
+        _cmd_doctor(verbose=False)
+        out = capsys.readouterr().out
+        assert "Graph integrity — 0 orphans · 0 dangling files" in out
 
 
 class TestDoctorWorkingTreeDirty:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -88,6 +88,72 @@ class TestKnowledgeGraph:
         assert kg.G.number_of_nodes() == 1
 
 
+class TestKnowledgeGraphIntegrity:
+    """COGNIREPO-201: integrity sweep — orphans + dangling file nodes."""
+
+    def test_clean_graph_reports_zero(self, tmp_path):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        (tmp_path / "auth.py").write_text("def verify_token(): pass\n", encoding="utf-8")
+        kg.add_node("auth.py", NodeType.FILE)
+        kg.add_node("auth.py::verify_token", NodeType.FUNCTION, file="auth.py")
+        kg.add_edge("auth.py::verify_token", "auth.py", EdgeType.DEFINED_IN)
+        report = kg.integrity_report(str(tmp_path))
+        assert report["orphans"] == []
+        assert report["dangling_files"] == []
+        assert report["swept_at"]
+
+    def test_orphan_restricted_to_file_function_class(self, tmp_path):
+        """MEMORY/SESSION/ERROR/QUERY/CONCEPT nodes are legitimately edge-free early on."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType
+        kg = KnowledgeGraph()
+        kg.add_node("orphan_fn", NodeType.FUNCTION, file="ghost.py")
+        kg.add_node("m1", NodeType.MEMORY)
+        kg.add_node("s1", NodeType.SESSION)
+        kg.add_node("e1", NodeType.ERROR)
+        kg.add_node("concept1", NodeType.CONCEPT)
+        report = kg.integrity_report(str(tmp_path))
+        assert report["orphans"] == ["orphan_fn"]
+
+    def test_dangling_file_detected_and_deduped(self, tmp_path):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::fn_a", NodeType.FUNCTION, file="gone.py")
+        kg.add_node("gone.py::fn_b", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::fn_a", "gone.py", EdgeType.DEFINED_IN)
+        kg.add_edge("gone.py::fn_b", "gone.py", EdgeType.DEFINED_IN)
+        report = kg.integrity_report(str(tmp_path))
+        # gone.py never existed under tmp_path — one dangling entry, not three.
+        assert report["dangling_files"] == ["gone.py"]
+
+    def test_repair_apply_removes_dangling_only(self, tmp_path):
+        """AC3: --apply removes danglers only; orphan CONCEPTs untouched."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        (tmp_path / "live.py").write_text("def keep(): pass\n", encoding="utf-8")
+        kg.add_node("live.py", NodeType.FILE)
+        kg.add_node("live.py::keep", NodeType.FUNCTION, file="live.py")
+        kg.add_edge("live.py::keep", "live.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("orphan_concept", NodeType.CONCEPT, unresolved=True)
+
+        report = kg.integrity_report(str(tmp_path))
+        for f in report["dangling_files"]:
+            kg.remove_file_nodes(f)
+
+        assert kg.node_exists("live.py") and kg.node_exists("live.py::keep")
+        assert not kg.node_exists("gone.py") and not kg.node_exists("gone.py::stale")
+        assert kg.node_exists("orphan_concept")  # untouched — no 'file' attr
+
+        report2 = kg.integrity_report(str(tmp_path))
+        assert report2["dangling_files"] == []
+
+
 class TestKnowledgeGraphCorruptionQuarantine:
     """COGNIREPO-103 AC2: a corrupt graph.pkl is quarantined, not silently overwritten."""
 

--- a/tests/test_graph_repair.py
+++ b/tests/test_graph_repair.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+"""
+tests/test_graph_repair.py — COGNIREPO-201: `cognirepo graph repair` CLI.
+
+Exercises _cmd_graph_repair() against a real KnowledgeGraph (isolated_cognirepo
+fixture chdirs into tmp_path), matching TC-201-1's dry-run-by-default / --apply flow.
+"""
+from __future__ import annotations
+
+
+class TestGraphRepair:
+    def test_dry_run_reports_without_mutating(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_graph_repair
+
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+        kg.save()
+
+        code = _cmd_graph_repair(apply=False)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "gone.py" in out
+        assert "Dry run" in out
+
+        # Nothing was mutated — reload from disk and confirm the node survives.
+        kg2 = KnowledgeGraph()
+        assert kg2.node_exists("gone.py")
+        assert kg2.node_exists("gone.py::stale")
+
+    def test_apply_prunes_danglers_only(self, isolated_cognirepo, capsys):
+        """AC3: --apply removes danglers only; orphan CONCEPTs untouched; prints counts."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_graph_repair
+
+        kg = KnowledgeGraph()
+        with open("live.py", "w", encoding="utf-8") as f:
+            f.write("def keep(): pass\n")
+        kg.add_node("live.py", NodeType.FILE)
+        kg.add_node("live.py::keep", NodeType.FUNCTION, file="live.py")
+        kg.add_edge("live.py::keep", "live.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("orphan_concept", NodeType.CONCEPT, unresolved=True)
+        kg.save()
+
+        code = _cmd_graph_repair(apply=True)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "Removed 2 node(s)" in out  # gone.py + gone.py::stale
+
+        kg2 = KnowledgeGraph()
+        assert kg2.node_exists("live.py") and kg2.node_exists("live.py::keep")
+        assert not kg2.node_exists("gone.py") and not kg2.node_exists("gone.py::stale")
+        assert kg2.node_exists("orphan_concept")
+
+    def test_no_dangling_files_reports_clean(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph
+        from interface.cli.main import _cmd_graph_repair
+
+        KnowledgeGraph().save()
+
+        code = _cmd_graph_repair(apply=False)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "no dangling file nodes found" in out

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -206,6 +206,16 @@ class TestNewMCPTools:
         result = graph_stats()
         assert isinstance(result["top_concepts"], list)
 
+    def test_graph_stats_integrity_block(self):
+        """COGNIREPO-201 AC1: graph_stats returns integrity {orphans, dangling_files, swept_at}."""
+        from interface.server.mcp_server import graph_stats
+        result = graph_stats()
+        assert "integrity" in result
+        integrity = result["integrity"]
+        assert isinstance(integrity["orphans"], list)
+        assert isinstance(integrity["dangling_files"], list)
+        assert integrity["swept_at"]
+
     def test_manifest_includes_new_tools(self):
         from interface.server.mcp_server import _build_manifest
         manifest = _build_manifest()


### PR DESCRIPTION
## Summary
- `KnowledgeGraph.integrity_report(repo_root)` — orphans (FILE/FUNCTION/CLASS, degree 0) + dangling_files (file no longer on disk, deduped per file), O(nodes).
- `graph_stats` MCP tool gains an output-only `integrity` block (no input schema change — 0 manifest tokens per the story's requirement).
- `doctor` flags nonzero orphans/dangling as a warning with a repair hint; 0/0 is OK.
- New `cognirepo graph repair [--apply]` — dry-run by default, prunes dangling file nodes via `remove_file_nodes()` on `--apply`. Orphan CONCEPT stubs are untouched (no `file` attr).

First story of epic COGNIREPO-200 (KGEpisodicHardening). Order per the epic doc: 201 → (202 ∥ 203) → 204 → 205.

## Test plan
- [x] `tests/test_graph.py::TestKnowledgeGraphIntegrity` — clean graph 0/0, orphan-type restriction, dangling dedup, apply-equivalent prune (danglers only, orphan CONCEPT untouched).
- [x] `tests/test_doctor.py::TestDoctorGraphIntegrity` — seeded dangling → WARN + repair hint + exit ≥1; clean → OK.
- [x] `tests/test_graph_repair.py::TestGraphRepair` (new) — dry-run doesn't mutate; `--apply` prunes exactly the dangling nodes; clean repo reports none found.
- [x] `tests/test_mcp_server.py::test_graph_stats_integrity_block`.
- [x] Full suite: 1322 passed, 5 skipped.
- [x] Live MCP verification (TC-201-1, `cognirepo_test_repo/easy`) — left for the user per skill.md step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)