### PR TITLE
COGNIREPO-203: Go call-graph completion + dynamic-dispatch annotation

### DIFF
--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/COGNIREPO-203.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/COGNIREPO-203.md
@@ -29,3 +29,25 @@ node "dynamic_dispatch". who_calls keeps its existing coverage_note behavior.
 - FIRST ACTION: check whether cognirepo_test_repo/advanced contains Go sources; if not, add a
   small Go fixture under tests/fixtures/ (TEST_SUITE marks this BLOCKED until resolved).
 - Dispatch heuristics are annotation-only — they must not fabricate CALLS edges.
+
+## Implementation notes (2026-08-08)
+- FIRST ACTION resolved: cognirepo_test_repo/advanced/moby (Docker) has 9992 real .go files —
+  no synthetic fixture needed for the live TEST_SUITE check. A hand-crafted inline fixture was
+  still added to tests/test_indexer_multilang.py (TestGoIndexing) for a deterministic,
+  version-controlled ≥10-call-site regression test per AC1/AC3.
+- Root cause of the missing Go method-call resolution: tree-sitter's Go `selector_expression`
+  names its method field `field`; the existing `_ts_collect_calls` only checked `property`
+  (the JS/TS field name), so `recv.Method()` calls were silently dropped for every Go file
+  ever indexed. Fixed with a fallback field lookup.
+- A SECOND, independent bug surfaced during live verification against moby: `_ts_collect_calls`'s
+  recursion depth cap (12) was too shallow for realistic nested code — a Go method wrapping an
+  if-statement around `append(x, Struct{Field: recv.Method()})` alone reaches depth 12-13,
+  dropping the innermost call. Raised the cap to 60. This affects call extraction for every
+  supported language, not just Go, though Go's method+conditional+composite-literal style
+  triggers it disproportionately.
+- Dynamic-dispatch heuristic added as `_detect_dynamic_dispatch()` (decorators/`register()`
+  calls/`__init_subclass__`) plus a separate post-index pass `_apply_entry_points_dispatch()`
+  for pyproject.toml/setup.cfg entry-points — both annotation-only (`dispatch:"dynamic"` +
+  `RELATES_TO` → `concept::dynamic_dispatch`), no fabricated CALLS edges (verified by test).
+- language_registry ↔ service_detect.py::_SERVICE_MARKERS already in sync for Go — no change
+  needed (confirmed per CLAUDE.md rule).

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/TEST/COGNIREPO-203-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/TEST/COGNIREPO-203-TEST_SUITE.md
@@ -1,22 +1,39 @@
 # COGNIREPO-203 — Manual test suite
 
 ## TC-203-1: Go caller resolution
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced — VERIFY it contains Go
-  sources first; if not, use the tests/fixtures Go fixture added by this story and note it here.
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced/moby — CONFIRMED it contains
+  real Go sources (Docker/moby, 9992 .go files); BLOCKED note resolved, no synthetic fixture
+  needed. Indexed a 22-file subset (daemon/container/) in isolation for tractable indexing time.
 - Prerequisites: story merged; repo (re)indexed.
-- What to do: hand-list the callers of one exported Go function (grep); compare who_calls.
-- Prompt: "Who calls <GoFunc>? Give file:line for each caller."
+- What to do: hand-list the callers of two exported Go methods (grep -n "\.Fn(" *.go, cross-
+  checked against enclosing func line ranges); compare against `cognirepo who-calls <Fn>`.
+- Prompt: "Who calls ResolvePath? Who calls ConfigsDirPath? Give file:line for each caller."
 - Expected results: ≥90% of the hand-verified list returned with correct locations; coverage
   note honest about the remainder.
-- Obtained results:
-- Verdict: (BLOCKED until Go-source presence in the test repo is confirmed)
+- Obtained results: Hand-verified callers — ResolvePath: {CreateSecretSymlinks (line 37),
+  CreateConfigSymlinks (line 87)}; ConfigsDirPath: {ConfigMounts (line 111), ConfigFilePath
+  (line 206)}. `who-calls ResolvePath` returned both (source:"graph"), plus the same 2 sites
+  again via the pre-existing text-scan fallback (found_via:"go_receiver_fallback", expected/
+  harmless — coverage_note fires whenever the static graph alone returns ≤2 callers).
+  `who-calls ConfigsDirPath` initially returned only ConfigFilePath (1/2) — investigation
+  found a second, independent bug: `_ts_collect_calls`'s recursion depth cap (12) was too
+  shallow for real code (a method + if-statement + `append(x, Struct{Field: recv.Method()})`
+  composite literal alone reaches depth 12-13), silently dropping the ConfigsDirPath() call
+  inside ConfigMounts's composite literal. Raised the cap to 60 (ast_indexer.py::
+  _ts_collect_calls) and confirmed both hand-verified pairs resolve via the graph after
+  reindexing. Final: 4/4 hand-verified callers resolved (100%, exceeds the 90% target).
+- Verdict: PASS
 
 ## TC-203-2: Dynamic dispatch annotation
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced (or fixture)
-- Prerequisites: as above; a celery-style task or plugin-register pattern present.
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/medium/celery
+  (examples/django/demoapp/tasks.py — real `@shared_task`-decorated functions).
+- Prerequisites: as above.
 - What to do: query the symbol via lookup_symbol/subgraph.
-- Prompt: "Look up <task_fn> — does CogniRepo know it's dynamically dispatched?"
+- Prompt: "Look up add — does CogniRepo know it's dynamically dispatched?"
 - Expected results: node carries dispatch:"dynamic"; subgraph links the dynamic_dispatch
   concept.
-- Obtained results:
-- Verdict:
+- Obtained results: `cognirepo subgraph add` on the indexed tasks.py fixture shows all 7
+  `@shared_task`-decorated functions (add, mul, xsum, count_widgets, rename_widget, error_task,
+  error_backoff_test) carrying `"dispatch": "dynamic"`, each with a `RELATES_TO` edge to a
+  `concept::dynamic_dispatch` CONCEPT node. No fabricated CALLS edges observed.
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -15,10 +15,12 @@ stories:
                         # cognirepo_test_repo/medium/celery, PASS. PR merged 2026-08-08,
                         # no review comments.
   - id: COGNIREPO-203
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-203
     pr: null
-    test_status: not-run
+    test_status: pass  # automated (1342 passed, 5 skipped, +11 new) + live TC-203-1
+                        # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
+                        # @shared_task, 7/7 tagged) — both PASS
   - id: COGNIREPO-204
     status: not-started
     branch: story/COGNIREPO-204

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -17,7 +17,7 @@ stories:
   - id: COGNIREPO-203
     status: in-review
     branch: story/COGNIREPO-203
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/49
     test_status: pass  # automated (1342 passed, 5 skipped, +11 new) + live TC-203-1
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
                         # @shared_task, 7/7 tagged) — both PASS

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 next
+    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 in-review (PR #49)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/README.md
+++ b/README.md
@@ -612,14 +612,32 @@ Priorities drawn from the v0.3.0 benchmark findings and community feedback. Now 
 some items below have since landed; each is annotated where that's the case.
 
 ### Near-term
-- **Go call-graph indexing** — *partially done:* Go IMPORTS edges (via `go.mod` scanning) and Go symbol/class indexing (tree-sitter `function_declaration`/`type_spec`) are implemented. Go-aware `who_calls`/CALLS edges are still missing — `_extract_calls()` (`intelligence/indexer/ast_indexer.py`) only walks Python's stdlib `ast`, not tree-sitter nodes, so Moby/Kubernetes call-graph tests (MO-3-5, K8-*) remain unblocked-but-incomplete for this specific edge type.
+- **Go call-graph indexing** — *done (COGNIREPO-203):* Go receiver-qualified method calls
+  (`recv.Method()`) now resolve through `who_calls`/CALLS edges — tree-sitter's Go
+  `selector_expression` names its method field `field`, not `property` (the JS convention the
+  extractor previously assumed), so method calls were silently dropped; fixed in
+  `_ts_collect_calls` (`intelligence/indexer/ast_indexer.py`). A second bug in the same
+  function — a call-collection recursion depth cap of 12, too shallow for a Go method wrapping
+  an if-statement around a composite-literal call argument — was also raised (to 60). Go
+  IMPORTS edges from `go.mod`-resolved local package imports are implemented
+  (`_extract_imports_go`/`_resolve_go_import_to_file`). Live-verified against
+  `cognirepo_test_repo/advanced/moby`: 4/4 hand-verified callers resolved (100%, vs. the 90%
+  target) after both fixes.
 - **`cognirepo ask`** — *done:* multi-model orchestrator (QUICK/STANDARD/COMPLEX/EXPERT tiers) is implemented and wired as a real CLI command (`_cmd_ask_local`, `interface/cli/main.py`). Streaming REPL mode (see Longer-term) is not yet built.
 - **Incremental re-index on save** — *done:* the file-watcher daemon (`cognirepo watch`) debounces writes (`config.json` → `indexing.debounce_ms`, default 500ms) and batches indexer/graph saves; `tests/test_watcher_debounce.py` covers this including flush-on-shutdown.
 - **CLAUDE.md mandatory-call relaxation** — benchmark feedback (Moby tests) flagged that forcing `context_pack` before every file read adds latency under memory pressure. A `--fast` mode that skips the tool-first gate for files under 50 lines is not yet implemented.
 
 ### Medium-term
 - **Kubernetes / 2M-LOC scale validation** — K8-1 through K8-5 test suite not yet completed. Goal: full scheduling-decision trace at < 8 000 tokens with CogniRepo vs. > 50 000 without.
-- **Plugin-registry pattern detection** — Ansible AN-3/AN-4 (22-level variable precedence, strategy plugins) and Celery CE-3 (dynamic dispatch) returned NA. Plan: static heuristic pass that detects `register`, `entry_points`, and `__init_subclass__` patterns and annotates them as `DYNAMIC_DISPATCH` nodes in the graph.
+- **Plugin-registry pattern detection** — *done (COGNIREPO-203):* a static, annotation-only
+  heuristic pass tags symbols reachable via dynamic dispatch — celery-style `@task`/
+  `@shared_task` decorators, `register(...)`-style plugin-registration calls, Python
+  `__init_subclass__` hooks, and packaging entry-points (`pyproject.toml`
+  `[project.entry-points.*]` / `setup.cfg` `[options.entry_points]`) — with `dispatch:"dynamic"`
+  plus a `RELATES_TO` edge to a `dynamic_dispatch` CONCEPT node (`_detect_dynamic_dispatch`,
+  `_apply_entry_points_dispatch` in `intelligence/indexer/ast_indexer.py`). Annotation-only by
+  design — never fabricates a CALLS edge. Live-verified against
+  `cognirepo_test_repo/medium/celery`'s real `@shared_task` functions.
 - **BM25 over symbol names** — *partially done:* `core/_bm25.py` is used by `intelligence/retrieval/hybrid.py` as the circuit-breaker fallback ranker (and by episodic search) when embeddings are unavailable, but it isn't yet the primary ranking signal for symbol-name partial-match recall (e.g. `HttpClient` matching `http_client`) in the normal (embeddings-available) retrieval path.
 - **Cross-session memory warm-up** — Ansible benchmark noted episodic/memory retrieval is low-value on fresh sessions. `cognirepo prime` exists but is not run automatically on `init`; will make it opt-in default.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -86,6 +86,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 | Behaviour tracking | ✅ | `data/graph/behaviour_tracker.py` — access frequency per node |
 | Entity extraction from text | ✅ | `data/graph/graph_utils.py::extract_entities_from_text()` |
 | `SIMILAR_TO` edges (embedding-distance near-duplicates, cross-file) | ✅ | Post-index FAISS k-NN pass, `intelligence/indexer/ast_indexer.py::_build_similarity_edges()` — gated via `config.json` → `indexing.similarity_edges` |
+| `dispatch:"dynamic"` annotation (celery tasks, plugin `register()`, `__init_subclass__`, packaging entry-points) | ✅ | `intelligence/indexer/ast_indexer.py::_detect_dynamic_dispatch()` / `_apply_entry_points_dispatch()` — annotation-only, `RELATES_TO` edge to `concept::dynamic_dispatch` |
 
 ---
 

--- a/docs/architecture/graph.md
+++ b/docs/architecture/graph.md
@@ -19,6 +19,18 @@
 | `NodeType.USER_ACTION` | `"USER_ACTION"` | A recorded user interaction |
 | `NodeType.MEMORY` | `"MEMORY"` | Cross-agent memory node (synced from Claude/Gemini/etc.) |
 
+### Node attributes
+
+- `dispatch: "dynamic"` (COGNIREPO-203) — set on a FUNCTION/CLASS node when a static heuristic
+  detects it's reachable via dynamic dispatch rather than a visible call site: a celery-style
+  `@task`/`@shared_task` decorator, a `register(...)`-style plugin-registration call, a Python
+  `__init_subclass__` hook, or a packaging entry-point (`pyproject.toml`
+  `[project.entry-points.*]` / `setup.cfg` `[options.entry_points]`). Annotation-only — it never
+  fabricates a CALLS edge; it adds a `RELATES_TO` edge to the well-known CONCEPT node
+  `concept::dynamic_dispatch` so `subgraph()` surfaces it. `who_calls` returning few/no static
+  callers for such a symbol is expected, not a graph-integrity gap — check `dispatch` before
+  trusting an empty caller list.
+
 ---
 
 ## Edge Type Glossary

--- a/intelligence/indexer/ast_indexer.py
+++ b/intelligence/indexer/ast_indexer.py
@@ -432,8 +432,15 @@ def _ts_docstring(node, source: bytes, ext: str) -> str:
 
 
 def _ts_collect_calls(node, source: bytes, out: list, depth: int = 0) -> None:
-    """Recursively collect function-call names from a tree-sitter subtree."""
-    if depth > 12:
+    """Recursively collect function-call names from a tree-sitter subtree.
+
+    COGNIREPO-203: the previous cap of 12 was too shallow for real code — a Go method
+    body wrapping an if-statement around `append(x, Struct{Field: recv.Method()})`
+    alone reaches depth 12-13 before the innermost call node is even visited, silently
+    dropping it. 60 comfortably covers realistic nesting while still bounding
+    pathological/generated input.
+    """
+    if depth > 60:
         return
     if node.type == "call":          # Python
         fn = node.child_by_field_name("function")
@@ -449,7 +456,10 @@ def _ts_collect_calls(node, source: bytes, out: list, depth: int = 0) -> None:
             or node.child_by_field_name("name")
         )
         if fn:
-            prop = fn.child_by_field_name("property")
+            prop = (
+                fn.child_by_field_name("property")  # JS/TS: obj.prop()
+                or fn.child_by_field_name("field")  # Go selector_expression: obj.Field()
+            )
             name_node = prop if prop else fn
             if name_node.type in ("identifier", "property_identifier", "field_identifier"):
                 method_name = _ts_text(name_node, source)
@@ -485,6 +495,24 @@ def _ts_decorators(parent_node, source: bytes) -> list[str]:
                     decs.append(_ts_text(sub, source).split("(")[0].strip())
                     break
     return decs
+
+
+# COGNIREPO-203: plugin-registry / dynamic-dispatch heuristics (README.md:626).
+# Annotation-only — these never fabricate CALLS edges, only flag a symbol as reachable
+# via a mechanism the static call graph can't see (framework registration, subclass
+# hooks), so who_calls callers can be cross-checked against dispatch:"dynamic" instead
+# of trusting an empty/short static caller list at face value.
+_DYNAMIC_DISPATCH_DECORATOR_TAILS = frozenset({"task", "shared_task"})  # celery-style
+
+
+def _detect_dynamic_dispatch(name: str, decorators: list[str], calls: list[str]) -> bool:
+    if name == "__init_subclass__":
+        return True
+    for dec in decorators:
+        tail = dec.rsplit(".", 1)[-1]
+        if tail in _DYNAMIC_DISPATCH_DECORATOR_TAILS:
+            return True
+    return "register" in calls
 
 
 def _ts_bases(node, source: bytes) -> list[str]:
@@ -528,30 +556,37 @@ def _walk_ts(node, source: bytes, ext: str, out: list, _parent_decs: "list[str] 
         if name_node:
             calls: list[str] = []
             _ts_collect_calls(node, source, calls)
+            fn_name = _ts_text(name_node, source)
+            fn_decs = _parent_decs or []
+            fn_calls = list(dict.fromkeys(calls))
             out.append({
-                "name": _ts_text(name_node, source),
+                "name": fn_name,
                 "type": "FUNCTION",
                 "start_line": node.start_point[0] + 1,
                 "end_line": node.end_point[0] + 1,
                 "docstring": _ts_docstring(node, source, ext),
-                "decorators": _parent_decs or [],
+                "decorators": fn_decs,
                 "tags": [],
-                "calls": list(dict.fromkeys(calls)),
+                "calls": fn_calls,
                 "bases": [],
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(fn_name, fn_decs, fn_calls) else None,
             })
     elif node.type in _TS_CLASS_TYPES:
         name_node = node.child_by_field_name("name")
         if name_node:
+            cls_name = _ts_text(name_node, source)
+            cls_decs = _parent_decs or []
             out.append({
-                "name": _ts_text(name_node, source),
+                "name": cls_name,
                 "type": "CLASS",
                 "start_line": node.start_point[0] + 1,
                 "end_line": node.end_point[0] + 1,
                 "docstring": _ts_docstring(node, source, ext),
-                "decorators": _parent_decs or [],
+                "decorators": cls_decs,
                 "tags": [],
                 "calls": [],
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(cls_name, cls_decs, []) else None,
                 "bases": _ts_bases(node, source),
                 "faiss_id": -1,
             })
@@ -654,6 +689,83 @@ def _resolve_import_to_file(
             if tracked_files is None or candidate in tracked_files:
                 return candidate
     return None
+
+
+# ── import extraction (Go) ─────────────────────────────────────────────────────
+
+_GO_MODULE_CACHE: "dict[str, str | None]" = {}
+
+
+def _go_module_name(repo_root: str) -> "str | None":
+    """Read the `module <path>` line from go.mod at the repo root (cached per root)."""
+    if repo_root in _GO_MODULE_CACHE:
+        return _GO_MODULE_CACHE[repo_root]
+    mod_name = None
+    try:
+        with open(os.path.join(repo_root, "go.mod"), encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("module "):
+                    mod_name = line[len("module "):].strip()
+                    break
+    except OSError:
+        pass
+    _GO_MODULE_CACHE[repo_root] = mod_name
+    return mod_name
+
+
+def _extract_imports_go(tree, source: bytes) -> list[dict]:
+    """Extract import_spec paths from a Go tree-sitter tree.
+
+    Returns list of dicts: {module, alias, line}. module is the raw import path
+    (e.g. "github.com/foo/bar/pkg/util"); alias is the local package name/alias.
+    """
+    imports: list[dict] = []
+
+    def _walk(node) -> None:
+        if node.type == "import_spec":
+            path_node = node.child_by_field_name("path")
+            if path_node:
+                raw = _ts_text(path_node, source).strip('"')
+                name_node = node.child_by_field_name("name")
+                alias = _ts_text(name_node, source) if name_node else raw.rsplit("/", 1)[-1]
+                imports.append({"module": raw, "alias": alias, "line": node.start_point[0] + 1})
+            return  # import_spec has no nested import_specs
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    return imports
+
+
+def _resolve_go_import_to_file(module: str, repo_root: str) -> "str | None":
+    """Resolve a Go import path to a representative local .go file.
+
+    Go packages are directories, not files — CogniRepo's IMPORTS edges are FILE→FILE,
+    so this picks the first non-test .go file (sorted) in the resolved package
+    directory as a stand-in for "this file imports that package". Only resolves
+    imports that belong to this repo's own module (per go.mod); stdlib/third-party
+    imports return None (nothing to link to locally), matching the Python resolver's
+    best-effort, local-only behaviour.
+    """
+    mod_name = _go_module_name(repo_root)
+    if not mod_name or not (module == mod_name or module.startswith(mod_name + "/")):
+        return None
+    rel_dir = module[len(mod_name):].lstrip("/")
+    abs_dir = os.path.join(repo_root, rel_dir) if rel_dir else repo_root
+    if not os.path.isdir(abs_dir):
+        return None
+    try:
+        go_files = sorted(
+            f for f in os.listdir(abs_dir)
+            if f.endswith(".go") and not f.endswith("_test.go")
+        )
+    except OSError:
+        return None
+    if not go_files:
+        return None
+    candidate = os.path.join(rel_dir, go_files[0]) if rel_dir else go_files[0]
+    return candidate.replace(os.sep, "/")
 
 
 # ── stdlib-ast extraction (Python fallback) ───────────────────────────────────
@@ -780,6 +892,7 @@ def _extract_symbols_py(tree: ast.AST, _file_path: str) -> list[dict]:
                 "tags": tags,
                 "dynamic_registers": dyn_targets,
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(node.name, decorators, calls) else None,
             })
 
         elif isinstance(node, ast.ClassDef):
@@ -804,6 +917,7 @@ def _extract_symbols_py(tree: ast.AST, _file_path: str) -> list[dict]:
                 "dynamic_registers": [],
                 "bases": bases,
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(node.name, _extract_decorators(node), []) else None,
             })
 
     # ── 2. module / class-level assignments → CONSTANT / VARIABLE ────────────
@@ -1524,12 +1638,17 @@ class ASTIndexer:
         self._build_reverse_index()
         # Resolve symbol:: stub nodes to real file-qualified nodes where unambiguous.
         _similarity_edges = 0
+        _entry_point_dispatch = 0
         if not getattr(self, "_skip_graph", False):
             self._resolve_call_stubs()
             try:
                 _similarity_edges = self._build_similarity_edges()
             except Exception as _exc:  # pylint: disable=broad-except
                 log.warning("SIMILAR_TO edge pass failed (graph still valid): %s", _exc)
+            try:
+                _entry_point_dispatch = self._apply_entry_points_dispatch()
+            except Exception as _exc:  # pylint: disable=broad-except
+                log.warning("entry_points dispatch pass failed (graph still valid): %s", _exc)
         total_symbols = sum(
             len(f.get("symbols", [])) for f in self.index_data["files"].values()
         )
@@ -1572,6 +1691,8 @@ class ASTIndexer:
             )
         if _similarity_edges:
             print(f"  SIMILAR_TO edges: {_similarity_edges}")
+        if _entry_point_dispatch:
+            print(f"  dispatch:dynamic (entry_points): {_entry_point_dispatch}")
 
         # NOTE: doc ingestion deliberately does NOT run here. Every entry point
         # (cli/main.py index-repo Stage 3, cli/init_project.py, init-all) invokes
@@ -1587,6 +1708,7 @@ class ASTIndexer:
             "skipped_extensions": sorted(skipped_exts),
             "tier2_queued": len(_tier2_pending),
             "similarity_edges": _similarity_edges,
+            "entry_point_dispatch": _entry_point_dispatch,
         }
 
     def index_file(self, rel_path: str, abs_path: str | None = None, weight: float = 1.0) -> dict:
@@ -1696,8 +1818,15 @@ class ASTIndexer:
                 file_node = make_node_id("FILE", rel_path)
                 sym_node = node_id_from_symbol_record(sym, rel_path)
                 self.graph.add_node(file_node, NodeType.FILE, weight=weight)
-                self.graph.add_node(sym_node, sym["type"], file=rel_path, line=sym["start_line"], weight=weight)
+                node_attrs = {"file": rel_path, "line": sym["start_line"], "weight": weight}
+                if sym.get("dispatch") == "dynamic":
+                    node_attrs["dispatch"] = "dynamic"
+                self.graph.add_node(sym_node, sym["type"], **node_attrs)
                 self.graph.add_edge(sym_node, file_node, EdgeType.DEFINED_IN)
+                if sym.get("dispatch") == "dynamic":
+                    dispatch_node = make_node_id("CONCEPT", "dynamic_dispatch")
+                    self.graph.add_node(dispatch_node, NodeType.CONCEPT)
+                    self.graph.add_edge(sym_node, dispatch_node, EdgeType.RELATES_TO)
 
         # ── file-level summary embedding ──────────────────────────────────────
         if embed_enabled and raw_symbols:
@@ -1776,6 +1905,24 @@ class ASTIndexer:
                         self.graph.add_node(target_node, NodeType.FILE)
                         self.graph.add_edge(file_node, target_node, EdgeType.IMPORTS)
             except (SyntaxError, OSError):
+                pass  # best-effort
+        elif ext == ".go":
+            try:
+                _go_lang = _get_language(ext)
+                if _go_lang is not None:
+                    from tree_sitter import Parser as _Parser  # pylint: disable=import-outside-toplevel
+                    _go_source = Path(abs_path).read_bytes()
+                    _go_tree = _Parser(_go_lang).parse(_go_source)
+                    _imports = _extract_imports_go(_go_tree, _go_source)
+                    _repo_root = self.index_data.get("repo_root") or os.getcwd()
+                    file_node = make_node_id("FILE", rel_path)
+                    for imp in _imports:
+                        _target = _resolve_go_import_to_file(imp["module"], _repo_root)
+                        if _target and _target != rel_path:
+                            target_node = make_node_id("FILE", _target)
+                            self.graph.add_node(target_node, NodeType.FILE)
+                            self.graph.add_edge(file_node, target_node, EdgeType.IMPORTS)
+            except OSError:
                 pass  # best-effort
 
         file_record = {
@@ -1962,6 +2109,67 @@ class ASTIndexer:
                     edges_added += 1
 
         return edges_added
+
+    def _apply_entry_points_dispatch(self) -> int:
+        """Post-index pass (COGNIREPO-203): tag symbols referenced by a packaging
+        entry-point (PEP 621 `[project.entry-points.*]` in pyproject.toml, or
+        `[options.entry_points]` in setup.cfg) as dispatch:"dynamic" — these are
+        invoked by name lookup at runtime (plugin loaders, console_scripts) rather
+        than a visible call site, so the static call graph can never find their
+        caller. Best-effort name match only (target's last dotted component vs.
+        symbol name) — does not verify the module path, matching the same
+        local-only, best-effort spirit as `_resolve_import_to_file`.
+        """
+        repo_root = self.index_data.get("repo_root") or os.getcwd()
+        targets: "set[str]" = set()
+
+        pyproject = os.path.join(repo_root, "pyproject.toml")
+        if os.path.isfile(pyproject):
+            try:
+                import tomllib  # pylint: disable=import-outside-toplevel
+                with open(pyproject, "rb") as f:
+                    data = tomllib.load(f)
+                for group in data.get("project", {}).get("entry-points", {}).values():
+                    for value in group.values():
+                        if ":" in value:
+                            targets.add(value.split(":")[-1].split(".")[-1].strip())
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        setup_cfg = os.path.join(repo_root, "setup.cfg")
+        if os.path.isfile(setup_cfg):
+            try:
+                import configparser  # pylint: disable=import-outside-toplevel
+                cp = configparser.ConfigParser()
+                cp.read(setup_cfg)
+                for section in cp.sections():
+                    if section == "options.entry_points" or section.startswith("options.entry_points."):
+                        for _key, value in cp.items(section):
+                            for line in value.splitlines():
+                                line = line.strip()
+                                if "=" in line:
+                                    _, target = line.split("=", 1)
+                                    target = target.strip()
+                                    if ":" in target:
+                                        targets.add(target.split(":")[-1].split(".")[-1].strip())
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        if not targets:
+            return 0
+
+        tagged = 0
+        dispatch_node = make_node_id("CONCEPT", "dynamic_dispatch")
+        for node_id, data in list(self.graph.G.nodes(data=True)):
+            if data.get("type") not in (NodeType.FUNCTION, NodeType.CLASS):
+                continue
+            name = node_id.rsplit("::", 1)[-1]
+            if name in targets and data.get("dispatch") != "dynamic":
+                self.graph.G.nodes[node_id]["dispatch"] = "dynamic"
+                self.graph.add_node(dispatch_node, NodeType.CONCEPT)
+                self.graph.add_edge(node_id, dispatch_node, EdgeType.RELATES_TO)
+                tagged += 1
+        return tagged
 
     # ── kept for ASTIndexer API compatibility ─────────────────────────────────
 

--- a/tests/test_indexer_multilang.py
+++ b/tests/test_indexer_multilang.py
@@ -219,6 +219,267 @@ class TestJavaIndexing:
         assert any(r["file"] == "Repo.java" for r in results)
 
 
+# ── Go (tree-sitter-go) ────────────────────────────────────────────────────────
+
+def _callers_of(graph, name: str) -> list[str]:
+    """Mirror of interface/server/mcp_server.py::who_calls's graph-only lookup —
+    successors of the symbol/stub-resolved node connected via a CALLS edge."""
+    from data.graph.knowledge_graph import EdgeType
+    node = f"symbol::{name}"
+    if not graph.G.has_node(node):
+        candidates = [
+            n for n in graph.G.nodes()
+            if n.endswith(f"::{name}") and not n.startswith("symbol::")
+        ]
+        if not candidates:
+            return []
+        node = candidates[0]
+    return [
+        succ for succ in graph.G.successors(node)
+        if graph.G[node][succ].get("rel") == EdgeType.CALLS
+    ]
+
+
+class TestGoIndexing:
+    """COGNIREPO-203 AC1 — Go selector_expression (receiver-qualified method) calls
+    must resolve through who_calls, not just plain function calls."""
+
+    _GO_FIXTURE = """\
+        package main
+
+        type Server struct{}
+
+        func (s *Server) Start() {
+            s.listen()
+            logStart()
+        }
+
+        func (s *Server) listen() {
+            accept()
+        }
+
+        func (s *Server) Stop() {
+            s.cleanup()
+        }
+
+        func (s *Server) cleanup() {}
+
+        func accept() {
+            handle()
+        }
+
+        func handle() {
+            process()
+        }
+
+        func process() {
+            validate()
+            save()
+        }
+
+        func validate() {}
+        func save() {}
+        func logStart() {}
+
+        func main() {
+            s := &Server{}
+            s.Start()
+            s.Stop()
+            setup()
+        }
+
+        func setup() {}
+    """
+
+    # Hand-verified callee -> caller pairs (11 call sites, per AC1's "≥10 incl. method calls").
+    _EXPECTED_CALLERS = {
+        "listen": "Start", "logStart": "Start", "cleanup": "Stop", "accept": "listen",
+        "handle": "accept", "process": "handle", "validate": "process", "save": "process",
+        "Start": "main", "Stop": "main", "setup": "main",
+    }
+
+    def test_go_functions_and_methods_extracted(self, fresh_indexer, tmp_path, monkeypatch):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        record = fresh_indexer.index_file("main.go", str(tmp_path / "main.go"))
+        names = [s["name"] for s in record["symbols"]]
+        assert "Server" in names
+        assert "Start" in names and "listen" in names and "Stop" in names
+
+    def test_go_selector_expression_call_captured(self, fresh_indexer, tmp_path, monkeypatch):
+        """Regression guard for the field-vs-property tree-sitter bug: Go's
+        selector_expression names its method field "field", not "property" (the JS
+        name) — before the fix, `s.listen()` inside Start() was silently dropped."""
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        record = fresh_indexer.index_file("main.go", str(tmp_path / "main.go"))
+        start_sym = next(s for s in record["symbols"] if s["name"] == "Start")
+        assert "listen" in start_sym["calls"]
+
+    def test_who_calls_resolves_at_least_90_percent_of_hand_verified_callers(
+        self, fresh_indexer, tmp_path, monkeypatch
+    ):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        fresh_indexer.index_repo(str(tmp_path))
+
+        resolved = 0
+        for callee, expected_caller in self._EXPECTED_CALLERS.items():
+            callers = _callers_of(fresh_indexer.graph, callee)
+            if any(c.endswith(f"::{expected_caller}") for c in callers):
+                resolved += 1
+        ratio = resolved / len(self._EXPECTED_CALLERS)
+        assert ratio >= 0.90, f"only {resolved}/{len(self._EXPECTED_CALLERS)} callers resolved"
+
+    def test_go_imports_edge_to_local_package(self, fresh_indexer, tmp_path, monkeypatch):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.21\n", encoding="utf-8")
+        util_dir = tmp_path / "util"
+        util_dir.mkdir()
+        _write(util_dir, "util.go", """\
+            package util
+
+            func Helper() {}
+        """)
+        _write(tmp_path, "main.go", """\
+            package main
+
+            import "example.com/demo/util"
+
+            func main() {
+                util.Helper()
+            }
+        """)
+        from data.graph.knowledge_graph import EdgeType
+        fresh_indexer.index_repo(str(tmp_path))
+        assert fresh_indexer.graph.G.has_edge("main.go", "util/util.go")
+        edge = fresh_indexer.graph.G["main.go"]["util/util.go"]
+        assert edge.get("rel") == EdgeType.IMPORTS
+
+    def test_go_external_import_not_resolved_locally(self, fresh_indexer, tmp_path, monkeypatch):
+        """stdlib/third-party imports (no go.mod match) must not fabricate edges."""
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.21\n", encoding="utf-8")
+        _write(tmp_path, "main.go", """\
+            package main
+
+            import "fmt"
+
+            func main() {
+                fmt.Println("hi")
+            }
+        """)
+        fresh_indexer.index_repo(str(tmp_path))
+        file_node = fresh_indexer.graph.G.nodes.get("main.go", {})
+        assert file_node  # file node itself still exists
+        assert fresh_indexer.graph.G.out_degree("main.go") == 0
+
+
+# ── Dynamic dispatch annotation (COGNIREPO-203 AC2) ────────────────────────────
+
+class TestDynamicDispatchAnnotation:
+    def test_celery_task_decorator_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "tasks.py", """\
+            from celery import shared_task
+
+            @shared_task
+            def send_email(to):
+                pass
+
+            @app.task
+            def process_order(order_id):
+                pass
+
+            def plain_function():
+                pass
+        """)
+        record = fresh_indexer.index_file("tasks.py", str(src))
+        by_name = {s["name"]: s for s in record["symbols"]}
+        assert by_name["send_email"]["dispatch"] == "dynamic"
+        assert by_name["process_order"]["dispatch"] == "dynamic"
+        assert by_name["plain_function"].get("dispatch") is None
+
+    def test_register_call_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        """Generic plugin-registry pattern (Ansible-module-style self-registration)."""
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "plugins.py", """\
+            def setup_plugin():
+                registry.register(MyPlugin)
+        """)
+        record = fresh_indexer.index_file("plugins.py", str(src))
+        sym = next(s for s in record["symbols"] if s["name"] == "setup_plugin")
+        assert sym["dispatch"] == "dynamic"
+
+    def test_init_subclass_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "plugin_base.py", """\
+            class PluginBase:
+                def __init_subclass__(cls, **kwargs):
+                    super().__init_subclass__(**kwargs)
+        """)
+        record = fresh_indexer.index_file("plugin_base.py", str(src))
+        sym = next(s for s in record["symbols"] if s["name"] == "__init_subclass__")
+        assert sym["dispatch"] == "dynamic"
+
+    def test_dispatch_dynamic_relates_to_concept_node(self, fresh_indexer, tmp_path, monkeypatch):
+        """dispatch:"dynamic" symbols get a RELATES_TO edge to the dynamic_dispatch
+        CONCEPT node, so subgraph()/graph queries surface them without a fabricated
+        CALLS edge (risk note: annotation-only)."""
+        monkeypatch.chdir(tmp_path)
+        from data.graph.knowledge_graph import EdgeType
+        src = _write(tmp_path, "tasks.py", """\
+            @shared_task
+            def send_email(to):
+                pass
+        """)
+        fresh_indexer.index_file("tasks.py", str(src))
+        sym_node = "tasks.py::send_email"
+        assert fresh_indexer.graph.G.nodes[sym_node].get("dispatch") == "dynamic"
+        assert fresh_indexer.graph.G.has_edge(sym_node, "concept::dynamic_dispatch")
+        assert fresh_indexer.graph.G[sym_node]["concept::dynamic_dispatch"]["rel"] == EdgeType.RELATES_TO
+
+    def test_entry_points_pyproject_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            """\
+            [project.entry-points."myapp.plugins"]
+            widget = "myapp.plugins.widget:load_widget"
+            """,
+            encoding="utf-8",
+        )
+        _write(tmp_path, "widget.py", """\
+            def load_widget():
+                pass
+        """)
+        fresh_indexer.index_repo(str(tmp_path))
+        assert fresh_indexer.graph.G.nodes["widget.py::load_widget"].get("dispatch") == "dynamic"
+
+    def test_no_fabricated_calls_edge_from_dispatch_tag(self, fresh_indexer, tmp_path, monkeypatch):
+        """Risk note: dispatch heuristics are annotation-only — no synthetic CALLS
+        edge should appear between a dispatch:"dynamic" symbol and anything else
+        purely because of the tag."""
+        monkeypatch.chdir(tmp_path)
+        from data.graph.knowledge_graph import EdgeType
+        src = _write(tmp_path, "tasks.py", """\
+            @shared_task
+            def send_email(to):
+                pass
+        """)
+        fresh_indexer.index_file("tasks.py", str(src))
+        sym_node = "tasks.py::send_email"
+        rels = {
+            fresh_indexer.graph.G[sym_node][succ].get("rel")
+            for succ in fresh_indexer.graph.G.successors(sym_node)
+        }
+        assert EdgeType.CALLS not in rels
+
+
 # ── language_registry ─────────────────────────────────────────────────────────
 
 class TestLanguageRegistry:


### PR DESCRIPTION
Ticket: `JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/COGNIREPO-203.md`

## Summary
**Go call-graph fixes** (`intelligence/indexer/ast_indexer.py::_ts_collect_calls`):
1. Go's tree-sitter `selector_expression` names its method field `field`, not `property`
   (the JS/TS convention the extractor assumed) — every receiver-qualified call
   (`recv.Method()`) was silently dropped from the call graph for every Go file ever
   indexed. Fixed with a field-name fallback.
2. Independently, the recursion depth cap (12) was too shallow for realistic nested code —
   a Go method wrapping an if-statement around `append(x, Struct{Field: recv.Method()})`
   alone reaches depth 12-13, dropping the innermost call regardless of language. Raised to 60.

Also added Go **IMPORTS edges** resolved via `go.mod` (`_extract_imports_go` /
`_resolve_go_import_to_file`), local-module-only and best-effort, matching the existing
Python import resolver's design.

**Dynamic-dispatch annotation** (`_detect_dynamic_dispatch`, `_apply_entry_points_dispatch`):
a static, annotation-only heuristic tags FUNCTION/CLASS symbols reachable via dynamic
dispatch — celery `@task`/`@shared_task` decorators, `register(...)`-style plugin calls,
`__init_subclass__` hooks, and `pyproject.toml`/`setup.cfg` packaging entry-points — with
`dispatch:"dynamic"` plus a `RELATES_TO` edge to a `dynamic_dispatch` CONCEPT node. Never
fabricates a CALLS edge (covered by a dedicated regression test).

## Acceptance criteria
- [x] Go fixture: who_calls resolves ≥90% of a hand-verified caller list (fixture with
      ≥10 call sites incl. method calls) — inline fixture in
      `tests/test_indexer_multilang.py::TestGoIndexing` (11 call sites, 100% resolved).
- [x] Celery/Ansible-style fixture symbols carry `dispatch:"dynamic"` —
      `TestDynamicDispatchAnnotation` covers decorator, `register()`, `__init_subclass__`,
      and entry-points patterns.
- [x] `tests/test_indexer_multilang.py` extended for both; suite green.
- [x] No Python-path regressions (golden lookup tests unchanged).

## Test plan
- `venv/bin/python -m pytest tests/ -q` → **1342 passed, 5 skipped** (was 1331 before this
  story; 11 new tests, all Python-path tests unchanged).
- **Live TC-203-1** against `cognirepo_test_repo/advanced/moby` (real Docker/moby Go source,
  9992 files — indexed a 22-file subset for tractable indexing time): hand-verified 4 caller
  pairs across 2 exported methods (`ResolvePath`, `ConfigsDirPath`) by grep; `who-calls`
  resolved **4/4 (100%)** via the static graph after both fixes — before the depth-cap fix,
  1 of the 4 was silently missed (a call inside a composite literal). Recorded in
  `STORY/COGNIREPO-203/TEST/COGNIREPO-203-TEST_SUITE.md`.
- **Live TC-203-2** against `cognirepo_test_repo/medium/celery`'s real
  `examples/django/demoapp/tasks.py`: all 7 real `@shared_task` functions correctly tagged
  `dispatch:"dynamic"` with a `RELATES_TO` edge to `concept::dynamic_dispatch`, no fabricated
  CALLS edges. PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)