### PR TITLE
COGNIREPO-204: Unified timeline (data/memory/timeline.py) + bootstrap digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ milestones, `record_error()` for any errors hit. This updates the profile for ne
 | Store user's style/format preference | `record_user_preference("key", "value")` |
 | User's interaction style | `get_user_profile()` — then apply framing_hints |
 | Avoid repeating past errors | `get_error_patterns()` — check before proposing a fix |
+| "What happened recently" (sessions + episodes + decisions + errors, one merged view) | `get_agent_bootstrap()`'s `recent_timeline` field (last 5, past 7 days) — replaces the `get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch. For a custom window/rollup, call `data.memory.timeline.merge()`/`rollup()` directly |
 | Record an error that occurred | `record_error("ErrorType", "message")` |
 
 ## Org search routing (pick the right tool)

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/COGNIREPO-204.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/COGNIREPO-204.md
@@ -34,3 +34,21 @@ existing output — 0 manifest tokens. Ground Rule 3 justification either way: r
 - Session-parser extraction must not change get_session_history behavior (golden test).
 - Timestamps are ISO strings across stores — normalize defensively (some old entries may lack
   timezone suffixes).
+
+## Implementation notes (2026-08-08)
+- AC4 (requires D02 merged): already satisfied — D02 (episodic ID collision after rotation)
+  was fixed and signed off under EPIC-100's defect slot (PR #34), predating this story.
+  `_next_event_id()` already produces store-lifetime-unique refs across live+archive. No new
+  defect needed; verified by reading `data/memory/episodic_memory.py` before coding.
+- Surface decision (per the "measure both" instruction): folded a 5-entry digest into
+  `get_agent_bootstrap()`'s existing output rather than a new `get_timeline` MCP tool.
+  Measured: standalone tool draft (signature + docstring, same detail level as this ticket's
+  Description) = **180 manifest-equivalent tokens** (tiktoken cl100k_base) — in line with the
+  ticket's own ~140 estimate. Folded approach = **0 manifest tokens** (`gen_tool_specs.py
+  --check` confirms manifest.json unchanged — no new `@mcp.tool()` registered). Chose folded:
+  Ground Rule 3 justification is stronger (replaces the 3-call stitch at zero manifest cost
+  instead of ~180), and `get_agent_bootstrap` is the tool already documented as the
+  session-start entry point.
+- Full `merge()`/`rollup()` API still lives in `data/memory/timeline.py` for direct use
+  (custom `since`/`include_archived`/`limit`) and as the data foundation for EPIC-300's
+  `generate_insights` tool, per the story's background.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
@@ -19,10 +19,15 @@
   — names both the decision and the error as required. One call either way (bootstrap digest
   or a single `merge()` call — no 3-call stitch).
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `cognirepo_test_repo/dummy` fixture (backup/restore
+  repeated), same seed shape, identical result — 7/7 entries, correct kind counts,
+  `rollup()` naming both the decision and the error; bootstrap digest cap (`merge(since=
+  "7d", limit=5)`) also spot-checked, returned the 5 most-recent as designed.
 
 ## TC-204-2: Archive inclusion
-- Test repo: scratch dir (isolated `.cognirepo/`, not a checked-in test repo — avoids
-  polluting a shared fixture with a synthetic 30-event rotation).
+- Test repo: `cognirepo_test_repo/TC-204-2` (dedicated scratch fixture, isolated
+  `.cognirepo/` — not the shared `dummy` fixture, avoids polluting it with a synthetic
+  30-event rotation).
 - Prerequisites: episodic_max_events lowered to 20; 30 events logged (rotation happened).
 - What to do: query with and without include_archived.
 - Prompt: "Show the full timeline including archived history, then just the recent one."
@@ -34,3 +39,6 @@
   30 refs, 30 unique — zero duplicates, confirming D02's fix (`_next_event_id()`) holds under
   a real rotation triggered by this story's merge logic, not just the isolated D02 test suite.
 - Verdict: PASS
+- Re-verified: 2026-08-12, `cognirepo_test_repo/TC-204-2` (fresh `cognirepo setup`,
+  `episodic_max_events` set to 20, 30 events logged), identical result — 18 live /
+  30 live+archived (12 archived), 30/30 unique episode refs.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
@@ -1,22 +1,36 @@
 # COGNIREPO-204 — Manual test suite
 
 ## TC-204-1: One-call timeline
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/medium
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/dummy (medium's size made ad-hoc
+  seeding slow; dummy's `.cognirepo/` was backed up before seeding and restored after).
 - Prerequisites: story merged; seed: 2 agent sessions, 3 log_episode, 1 record_decision,
   1 record_error.
 - What to do: call the shipped surface (get_timeline or bootstrap digest).
 - Prompt: "What happened in this repo in the last 7 days? Use a single CogniRepo call."
 - Expected results: all seeded items, chronological, kinds labeled; rollup readable and
   mentions the decision; exactly one tool call needed.
-- Obtained results:
-- Verdict:
+- Obtained results: `get_agent_bootstrap()`'s `recent_timeline` (5-entry cap) correctly
+  surfaced the 5 most-recent of the 7 seeded items (the 2 older sessions fell outside the
+  cap, as designed). Calling `data.memory.timeline.merge(since="30d", limit=100)` directly
+  (the full query surface behind the digest) returned all 7 seeded entries, newest first,
+  correctly kind-labeled (3 episode, 2 session, 1 decision, 1 error). `rollup()` over those 7:
+  `{"total": 7, "counts": {"error": 1, "decision": 1, "episode": 3, "session": 2},
+  "top_decisions": ["switch session storage to SQLite"], "top_errors": ["ConnectionError (x1)"]}`
+  — names both the decision and the error as required. One call either way (bootstrap digest
+  or a single `merge()` call — no 3-call stitch).
+- Verdict: PASS
 
 ## TC-204-2: Archive inclusion
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/dummy
+- Test repo: scratch dir (isolated `.cognirepo/`, not a checked-in test repo — avoids
+  polluting a shared fixture with a synthetic 30-event rotation).
 - Prerequisites: episodic_max_events lowered to 20; 30 events logged (rotation happened).
 - What to do: query with and without include_archived.
 - Prompt: "Show the full timeline including archived history, then just the recent one."
 - Expected results: archived events present only in the first; counts differ accordingly; no
   duplicate IDs (D02).
-- Obtained results:
-- Verdict:
+- Obtained results: `include_archived=False` returned 18 entries (live only);
+  `include_archived=True` returned all 30 (live + archived). Checked all 30 episode `ref`
+  values (the episodic `id` field) for uniqueness across the combined live+archive set:
+  30 refs, 30 unique — zero duplicates, confirming D02's fix (`_next_event_id()`) holds under
+  a real rotation triggered by this story's merge logic, not just the isolated D02 test suite.
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -22,10 +22,12 @@ stories:
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
                         # @shared_task, 7/7 tagged) — both PASS. PR merged 2026-08-08.
   - id: COGNIREPO-204
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-204
     pr: null
-    test_status: not-run
+    test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
+                        # (7/7 seeded entries, rollup names decision+error) and
+                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS
   - id: COGNIREPO-205
     status: not-started
     branch: story/COGNIREPO-205

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -24,7 +24,7 @@ stories:
   - id: COGNIREPO-204
     status: in-review
     branch: story/COGNIREPO-204
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/50
     test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
                         # (7/7 seeded entries, rollup names decision+error) and
                         # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -27,7 +27,10 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/50
     test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
                         # (7/7 seeded entries, rollup names decision+error) and
-                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS
+                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS.
+                        # Re-verified 2026-08-12 against cognirepo_test_repo/dummy (TC-204-1)
+                        # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
+                        # identical results both times.
   - id: COGNIREPO-205
     status: not-started
     branch: story/COGNIREPO-205

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 next
+    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 in-review (PR #50)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/data/memory/timeline.py
+++ b/data/memory/timeline.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+data/memory/timeline.py — COGNIREPO-204 unified timeline.
+
+Merges three independently-written stores — episodic events (log_episode/
+record_decision), session-exchange files (session_listener), and behaviour-tracked
+error patterns — into one chronologically ordered view, plus a deterministic
+template rollup (counts + top items; no model-generated text).
+
+Replaces the get_session_history + episodic_search + get_error_patterns 3-call
+stitch an agent previously had to do by hand to answer "what happened".
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+from core.config.paths import get_path
+from data.memory.episodic_memory import _archive_path, _load as _load_episodic
+
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _parse_ts(raw: "str | None") -> datetime:
+    """Normalize an ISO timestamp string for sorting/filtering.
+
+    Some older entries lack a timezone suffix — treat those as UTC so they sort
+    consistently against tz-aware entries instead of raising on comparison.
+    Unparseable/missing timestamps sort first (oldest), not raise.
+    """
+    if not raw:
+        return _EPOCH
+    try:
+        s = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return _EPOCH
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _parse_since(since: "str | None") -> datetime:
+    """Parse a relative duration ("7d", "24h", "30m") or an ISO timestamp.
+    Falls back to 7 days ago on anything unparseable.
+    """
+    now = _now()
+    if not since:
+        return now - timedelta(days=7)
+    m = re.match(r"^(\d+)([dhm])$", since.strip())
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {"d": timedelta(days=n), "h": timedelta(hours=n), "m": timedelta(minutes=n)}[unit]
+        return now - delta
+    parsed = _parse_ts(since)
+    return parsed if parsed is not _EPOCH else now - timedelta(days=7)
+
+
+def parse_session_file(path: str) -> "dict | None":
+    """Extract session_id/created_at/message_count/last_exchange from one session
+    JSON file.
+
+    Shared by get_session_history (interface/server/mcp_server.py) and the
+    timeline merge — extracted here so both read one implementation instead of
+    two independently-maintained copies of the same last-exchange parsing.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    messages = data.get("messages", [])
+    last_exchange: dict = {}
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].get("role") == "assistant":
+            last_exchange["assistant"] = messages[i].get("content", "")[:300]
+        elif messages[i].get("role") == "user" and "assistant" in last_exchange:
+            last_exchange["user"] = messages[i].get("content", "")[:300]
+            break
+    return {
+        "session_id": data.get("session_id", os.path.basename(path)),
+        "created_at": data.get("created_at"),
+        "message_count": len(messages),
+        "model": data.get("model", "unknown"),
+        "last_exchange": last_exchange,
+    }
+
+
+def _list_session_files() -> list[str]:
+    sessions_dir = get_path("sessions")
+    if not os.path.isdir(sessions_dir):
+        return []
+    files = glob.glob(os.path.join(sessions_dir, "*.json"))
+    return [f for f in files if not f.endswith("current.json")]
+
+
+def _session_entries() -> list[dict]:
+    entries = []
+    for sf in sorted(_list_session_files()):  # fixed disk-order input for determinism
+        parsed = parse_session_file(sf)
+        if parsed is None or not parsed.get("created_at"):
+            continue
+        exch = parsed.get("last_exchange", {})
+        summary = exch.get("user") or exch.get("assistant") or f"{parsed['message_count']} messages"
+        entries.append({
+            "ts": parsed["created_at"],
+            "kind": "session",
+            "summary": summary[:160],
+            "ref": parsed["session_id"],
+        })
+    return entries
+
+
+def _episodic_entries(include_archived: bool) -> list[dict]:
+    data = list(_load_episodic())
+    if include_archived:
+        apath = _archive_path()
+        if os.path.exists(apath):
+            try:
+                with open(apath, "rb") as f:
+                    data = json.loads(f.read()) + data
+            except (OSError, json.JSONDecodeError):
+                pass
+    entries = []
+    for e in data:
+        meta = e.get("metadata", {}) or {}
+        kind = "decision" if meta.get("type") == "decision" else "episode"
+        summary = meta.get("summary") or e.get("event", "")
+        entries.append({
+            "ts": e.get("time"),
+            "kind": kind,
+            "summary": summary[:160],
+            "ref": e.get("id", ""),
+        })
+    return entries
+
+
+def _error_entries() -> list[dict]:
+    try:
+        from data.graph.knowledge_graph import KnowledgeGraph  # pylint: disable=import-outside-toplevel
+        from data.graph.behaviour_tracker import BehaviourTracker  # pylint: disable=import-outside-toplevel
+        patterns = BehaviourTracker(KnowledgeGraph()).get_error_patterns(min_count=1)
+    except Exception:  # pylint: disable=broad-except
+        return []
+    return [
+        {
+            "ts": p.get("last_seen"),
+            "kind": "error",
+            "summary": f"{p['error_type']} (x{p['count']})",
+            "ref": p["error_type"],
+        }
+        for p in patterns
+        if p.get("last_seen")
+    ]
+
+
+def merge(since: str = "7d", include_archived: bool = False, limit: int = 100) -> list[dict]:
+    """Return timeline entries — {ts, kind, summary, ref} — newest first.
+
+    kind is one of: session, episode, decision, error. Entries older than
+    `since` (a relative duration like "7d"/"24h"/"30m", or an ISO timestamp)
+    are excluded. Deterministic: sorts by (timestamp desc, kind, ref) so ties
+    (equal or missing timestamps) always resolve the same way for identical
+    store state — required for byte-identical output (AC3).
+    """
+    cutoff = _parse_since(since)
+    raw = _session_entries() + _episodic_entries(include_archived) + _error_entries()
+    dated = [(e, _parse_ts(e.get("ts"))) for e in raw]
+    dated = [(e, dt) for e, dt in dated if dt >= cutoff]
+    dated.sort(key=lambda pair: (pair[1], pair[0]["kind"], pair[0]["ref"]), reverse=True)
+    return [e for e, _ in dated[:limit]]
+
+
+def rollup(entries: list[dict]) -> dict:
+    """Deterministic template rollup over merge() output — counts + top items,
+    no model-generated text. Foundation for EPIC-300's insights report.
+    """
+    counts: dict[str, int] = {}
+    decisions: list[str] = []
+    errors: list[str] = []
+    for e in entries:
+        counts[e["kind"]] = counts.get(e["kind"], 0) + 1
+        if e["kind"] == "decision":
+            decisions.append(e["summary"])
+        elif e["kind"] == "error":
+            errors.append(e["summary"])
+    return {
+        "total": len(entries),
+        "counts": counts,
+        "top_decisions": decisions[:3],
+        "top_errors": errors[:3],
+    }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -327,7 +327,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-93 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+94 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -611,9 +611,24 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
   "last_focus": {"files": ["retrieval/hybrid.py"], "query": "how does scoring work", "agent": "claude"},
   "framing": {"depth": "detailed", "vocabulary": ["retrieval", "faiss", "hybrid"], "hints": "prefers detailed responses; often asks 'how' questions; domain vocabulary: retrieval, faiss, hybrid"},
   "error_patterns": [{"type": "OOM", "count": 2, "prevention_hint": "Check RSS before loading large index"}],
-  "index_health": {"symbols": 1240, "files": 92, "status": "ok"}
+  "index_health": {"symbols": 1240, "files": 92, "status": "ok"},
+  "recent_timeline": [
+    {"ts": "2026-08-08T09:00:00+00:00", "kind": "decision", "summary": "use FAISS for vector search", "ref": "e_42"},
+    {"ts": "2026-08-07T14:00:00+00:00", "kind": "error", "summary": "ImportError (x3)", "ref": "ImportError"},
+    {"ts": "2026-08-06T11:00:00+00:00", "kind": "session", "summary": "how does scoring work", "ref": "sess_abc123"}
+  ]
 }
 ```
+
+**recent_timeline** (COGNIREPO-204): last 5 entries from the past 7 days, merged
+chronologically across sessions, episodes, decisions, and errors — replaces the
+`get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch for a
+quick "what happened recently" view. Folded into this tool's existing output rather
+than a new MCP tool (0 manifest tokens vs. ~180 measured for a standalone
+`get_timeline` tool). For the full query surface (`since`/`include_archived`/`limit`,
+plus the deterministic `rollup()` — counts + top decisions/errors, no model-generated
+text), call `data.memory.timeline.merge()`/`rollup()` directly, or from a future
+`generate_insights` tool (EPIC-300).
 
 ---
 

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1800,41 +1800,13 @@ def get_session_history(limit: int = 10, repo_path: str | None = None) -> list:
     repo_path: optional absolute path to the target repository.
     """
     with _repo_ctx(repo_path):
-        from core.config.paths import get_path as _gp  # pylint: disable=import-outside-toplevel
-        import glob  # pylint: disable=import-outside-toplevel
-        sessions_dir = _gp("sessions")
-        if not os.path.isdir(sessions_dir):
-            return []
-        session_files = sorted(
-            glob.glob(os.path.join(sessions_dir, "*.json")),
-            key=os.path.getmtime,
-            reverse=True,
-        )
-        # exclude the "current.json" pointer file
-        session_files = [f for f in session_files if not f.endswith("current.json")]
+        from data.memory.timeline import _list_session_files, parse_session_file  # pylint: disable=import-outside-toplevel
+        session_files = sorted(_list_session_files(), key=os.path.getmtime, reverse=True)
         results = []
         for sf in session_files[:limit]:
-            try:
-                with open(sf, encoding="utf-8") as f:
-                    data = json.load(f)
-                messages = data.get("messages", [])
-                # get last user/assistant exchange
-                last_exchange = {}
-                for i in range(len(messages) - 1, -1, -1):
-                    if messages[i].get("role") == "assistant":
-                        last_exchange["assistant"] = messages[i].get("content", "")[:300]
-                    elif messages[i].get("role") == "user" and "assistant" in last_exchange:
-                        last_exchange["user"] = messages[i].get("content", "")[:300]
-                        break
-                results.append({
-                    "session_id": data.get("session_id", os.path.basename(sf)),
-                    "created_at": data.get("created_at"),
-                    "message_count": len(messages),
-                    "model": data.get("model", "unknown"),
-                    "last_exchange": last_exchange,
-                })
-            except (OSError, json.JSONDecodeError):
-                continue
+            parsed = parse_session_file(sf)
+            if parsed is not None:
+                results.append(parsed)
     return results
 
 
@@ -1853,6 +1825,10 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
       framing       — {depth, vocabulary} from user profile (empty if tracking off)
       error_patterns — top 3 recurring errors with prevention hints
       index_health  — {symbols, files, status}
+      recent_timeline — last 5 entries (past 7 days) merged across sessions,
+                        episodes, decisions, and errors — {ts, kind, summary, ref}
+                        each; see data/memory/timeline.py::merge() for the full
+                        query surface (since/include_archived/limit)
 
     Claude: call this ONCE at session start instead of the 4 individual calls.
     Use individual tools only when you need the full detail each provides.
@@ -1951,6 +1927,18 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         except Exception:  # pylint: disable=broad-except
             pass
 
+        # ── recent timeline digest (COGNIREPO-204) ──────────────────────────────
+        # 5-entry digest folded into bootstrap's existing output rather than a new
+        # MCP tool — 0 manifest tokens vs. ~140 for a standalone get_timeline
+        # (measured on the PR), replacing what would otherwise be a 3-call stitch
+        # (get_session_history + episodic_search + get_error_patterns).
+        recent_timeline: list = []
+        try:
+            from data.memory.timeline import merge as _timeline_merge  # pylint: disable=import-outside-toplevel
+            recent_timeline = _timeline_merge(since="7d", limit=5)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     # ── child services (orchestrator repos only) ──────────────────────────────
     child_services: list[dict] = []
     try:
@@ -1985,6 +1973,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         "framing": framing,
         "error_patterns": error_patterns,
         "index_health": {"symbols": symbol_count, "files": file_count, "status": index_status},
+        "recent_timeline": recent_timeline,
     }
     if child_services:
         result["child_services"] = child_services

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,178 @@
+# pylint: disable=missing-docstring, redefined-outer-name, protected-access
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_timeline.py — COGNIREPO-204 acceptance criteria.
+
+data/memory/timeline.py merges episodic (live + archive), session-exchange files,
+and behaviour error patterns into one chronologically ordered view, plus a
+deterministic template rollup.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.config.paths import get_path
+
+
+def _write_session(sessions_dir: Path, session_id: str, created_at: str, user_msg: str) -> None:
+    (sessions_dir / f"{session_id}.json").write_text(
+        json.dumps({
+            "session_id": session_id,
+            "created_at": created_at,
+            "model": "claude-sonnet-5",
+            "messages": [
+                {"role": "user", "content": user_msg},
+                {"role": "assistant", "content": "ack"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+
+def _log_episode(event: str, ts_override: str, metadata: dict | None = None) -> None:
+    """Log via the real episodic_memory module, then force a specific timestamp
+    (log_event always stamps "now" — tests need controlled, distinct timestamps
+    to assert ordering deterministically)."""
+    from data.memory.episodic_memory import log_event, _load, _save  # pylint: disable=import-outside-toplevel
+    log_event(event, metadata)
+    data = _load()
+    data[-1]["time"] = ts_override
+    _save(data)
+
+
+def _record_error(error_type: str, ts_override: str) -> None:
+    from data.graph.knowledge_graph import KnowledgeGraph  # pylint: disable=import-outside-toplevel
+    from data.graph.behaviour_tracker import BehaviourTracker  # pylint: disable=import-outside-toplevel
+    bt = BehaviourTracker(KnowledgeGraph())
+    bt.record_error(error_type, file_path="app.py", message="boom")
+    bt.data["error_patterns"][error_type]["last_seen"] = ts_override
+    bt.save()
+
+
+class TestTimelineMerge:
+    def test_merge_returns_seven_ordered_entries_ac1(self, tmp_path, monkeypatch):
+        """AC1: 2 sessions + 3 episodes + 1 decision + 1 error -> 7 ordered entries;
+        rollup names the decision and the error."""
+        from data.memory import timeline
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "s1", "2026-08-01T10:00:00+00:00", "how does auth work")
+        _write_session(sessions_dir, "s2", "2026-08-02T10:00:00+00:00", "fix the flaky test")
+
+        _log_episode("indexed repo", "2026-08-01T11:00:00+00:00")
+        _log_episode("ran benchmark", "2026-08-02T11:00:00+00:00")
+        _log_episode("reviewed PR", "2026-08-03T11:00:00+00:00")
+        _log_episode(
+            "decision: use FAISS for vector search", "2026-08-03T12:00:00+00:00",
+            metadata={"type": "decision", "summary": "use FAISS for vector search"},
+        )
+        _record_error("ImportError", "2026-08-03T13:00:00+00:00")
+
+        entries = timeline.merge(since="30d", limit=100)
+        assert len(entries) == 7
+        kinds = [e["kind"] for e in entries]
+        assert kinds.count("session") == 2
+        assert kinds.count("episode") == 3
+        assert kinds.count("decision") == 1
+        assert kinds.count("error") == 1
+
+        # newest first
+        timestamps = [e["ts"] for e in entries]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+        rollup = timeline.rollup(entries)
+        assert rollup["total"] == 7
+        assert rollup["counts"] == {"session": 2, "episode": 3, "decision": 1, "error": 1}
+        assert any("FAISS" in d for d in rollup["top_decisions"])
+        assert any("ImportError" in e for e in rollup["top_errors"])
+
+    def test_include_archived_default_excludes_ac2(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        from data.memory.episodic_memory import log_event
+
+        log_event("live entry")
+        archive_path = get_path("memory/episodic_archive.json")
+        Path(archive_path).write_text(json.dumps([{
+            "id": "e_archived_1", "event": "archived entry",
+            "metadata": {}, "time": "2026-01-01T00:00:00+00:00",
+        }]), encoding="utf-8")
+
+        default_entries = timeline.merge(since="3650d", include_archived=False)
+        assert "archived entry" not in [e["summary"] for e in default_entries]
+
+        archived_entries = timeline.merge(since="3650d", include_archived=True)
+        assert "archived entry" in [e["summary"] for e in archived_entries]
+
+    def test_since_filters_old_entries(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        from datetime import datetime, timezone
+
+        monkeypatch.setattr(timeline, "_now", lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+        _log_episode("very old event", "2020-01-01T00:00:00+00:00")
+        _log_episode("recent event", "2026-08-05T00:00:00+00:00")
+
+        entries = timeline.merge(since="30d")
+        summaries = [e["summary"] for e in entries]
+        assert "recent event" in summaries
+        assert "very old event" not in summaries
+
+    def test_deterministic_byte_identical_output_ac3(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+
+        _write_session(Path(get_path("sessions")), "s1", "2026-08-01T10:00:00+00:00", "hello")
+        _log_episode("event a", "2026-08-01T11:00:00+00:00")
+        _log_episode("event b", "2026-08-01T11:00:00+00:00")  # same ts as "event a" — tie
+        _record_error("TypeError", "2026-08-01T12:00:00+00:00")
+
+        first = json.dumps(timeline.merge(since="30d"), sort_keys=True)
+        second = json.dumps(timeline.merge(since="30d"), sort_keys=True)
+        assert first == second
+
+    def test_empty_store_returns_empty_list(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        assert timeline.merge() == []
+
+
+class TestSessionParserExtraction:
+    """Risk note: session-parser extraction must not change get_session_history
+    behavior (golden test)."""
+
+    def test_get_session_history_matches_parse_session_file(self, tmp_path, monkeypatch):
+        from data.memory.timeline import parse_session_file
+        from interface.server.mcp_server import get_session_history
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "golden", "2026-08-01T10:00:00+00:00", "test query")
+
+        via_tool = get_session_history(limit=5)
+        assert len(via_tool) == 1
+
+        via_parser = parse_session_file(str(sessions_dir / "golden.json"))
+        assert via_tool[0] == via_parser
+
+    def test_get_session_history_unaffected_by_current_json(self, tmp_path, monkeypatch):
+        from interface.server.mcp_server import get_session_history
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "real", "2026-08-01T10:00:00+00:00", "hi")
+        (sessions_dir / "current.json").write_text('{"pointer": "real"}', encoding="utf-8")
+
+        results = get_session_history(limit=10)
+        assert len(results) == 1
+        assert results[0]["session_id"] == "real"
+
+
+class TestBootstrapTimelineDigest:
+    def test_bootstrap_includes_recent_timeline(self, tmp_path, monkeypatch):
+        from interface.server.mcp_server import get_agent_bootstrap
+
+        _write_session(Path(get_path("sessions")), "s1", "2026-08-01T10:00:00+00:00", "hi")
+        result = get_agent_bootstrap()
+        assert "recent_timeline" in result
+        assert isinstance(result["recent_timeline"], list)


### PR DESCRIPTION
Ticket: `JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/COGNIREPO-204.md`

## Summary
New `data/memory/timeline.py`:
- `merge(since, include_archived, limit)` — merges episodic events (`log_episode`/
  `record_decision`, live + optionally archived), session-exchange files, and
  behaviour-tracked error patterns into one chronologically ordered view
  (`{ts, kind, summary, ref}`, `kind` ∈ session/episode/decision/error).
- `rollup(entries)` — deterministic template rollup (counts + top decisions/errors,
  no model-generated text) — data foundation for EPIC-300's insights report.

Replaces the `get_session_history` + `episodic_search` + `get_error_patterns` 3-call
stitch an agent previously had to do by hand.

Extracted the session-file parser (`parse_session_file`) out of
`interface/server/mcp_server.py::get_session_history` into the data layer so both share
one implementation — `get_session_history`'s own output is unchanged (golden test).

**Surface decision** (ticket asked to measure both): folded a 5-entry digest into
`get_agent_bootstrap()`'s existing output rather than a new `get_timeline` MCP tool.
- Standalone tool draft (same detail as the ticket's Description): **180
  manifest-equivalent tokens** (tiktoken `cl100k_base`).
- Folded into bootstrap: **0 manifest tokens** — `gen_tool_specs.py --check` confirms
  `manifest.json` is unchanged (no new `@mcp.tool()` registered).
- Chose folded: stronger Ground Rule 3 justification (0 cost vs. ~180), and
  `get_agent_bootstrap` is already the documented session-start entry point.

**AC4** ("requires D02 merged"): already satisfied — D02 (episodic ID collision after
rotation) was fixed and signed off under EPIC-100's defect slot (PR #34) *before* this
story started. Verified by reading `episodic_memory.py` first per the analysis step —
`_next_event_id()` already produces store-lifetime-unique refs; no new defect needed.

## Acceptance criteria
- [x] Fixture with 2 sessions + 3 episodes + 1 decision + 1 error → one call returns 7
      ordered entries; rollup names the decision and error.
- [x] `include_archived=True` returns rotated events; default excludes them.
- [x] Deterministic: same store state ⇒ byte-identical output.
- [x] Requires D02 merged — confirmed already merged (PR #34).
- [x] `docs/MCP_TOOLS.md` + `CLAUDE.md` routing table updated for the shipped surface.

## Test plan
- `venv/bin/python -m pytest tests/ -q` → **1350 passed, 5 skipped** (was 1342 before
  this story; 8 new tests). One unrelated flake
  (`test_singleton_staleness.py::test_pid_file_and_heartbeat_removed_on_clean_exit`)
  reproduced once under full-suite load, passed cleanly in isolation and on a full
  suite re-run — not caused by this change.
- **Live TC-204-1**: seeded 2 sessions + 3 episodes + 1 decision + 1 error in
  `cognirepo_test_repo/dummy` (backed up/restored around the test). `merge()` returned
  all 7, newest first, correctly kind-labeled; `rollup()` named both the decision
  (`"switch session storage to SQLite"`) and the error (`"ConnectionError (x1)"`).
- **Live TC-204-2**: lowered `episodic_max_events` to 20, logged 30 events (triggering
  real rotation) in an isolated scratch store. `include_archived=False` → 18 (live
  only); `include_archived=True` → 30 (live + archived). Checked all 30 episode refs
  for uniqueness — 30/30 unique, confirming D02's fix holds under this story's own
  merge logic, not just the isolated D02 test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)