### PR TITLE
COGNIREPO-205: episodic archive search, embedding cache, index_event logging

### DIFF
--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
@@ -8,8 +8,13 @@
 - Prompt: "Search episodic memory for 'zanzibar', including archived history."
 - Expected results: hit found with flag on; miss (or empty) with flag off; response marks it
   archived.
-- Obtained results:
-- Verdict:
+- Obtained results: `episodic_max_events` set to 20 in `dummy/.cognirepo/config.json`
+  (backed up/restored around the test); logged 30 events, event #1 = "zanzibar migration
+  notes and rollout plan" (rotated into `episodic_archive.json` — live count 18, archive
+  count 12). `search_episodes("zanzibar", include_archived=False)` → 0 results.
+  `search_episodes("zanzibar", include_archived=True)` → hit found (`e_0`, the seeded
+  entry), tagged `{"archived": true}`.
+- Verdict: PASS
 
 ## TC-205-2: System events land in the timeline
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy
@@ -17,5 +22,10 @@
 - What to do: run `cognirepo index-repo .`; then query the timeline/episodic log.
 - Prompt: "What system/indexing events happened in this repo today?"
 - Expected results: exactly one index_event episode with file/symbol counts metadata.
-- Obtained results:
-- Verdict:
+- Obtained results: ran `cognirepo index-repo . --no-watch` against
+  `cognirepo_test_repo/easy/fastapi` (`.cognirepo/` backed up/restored around the test).
+  Episodic log after the run contained exactly 1 entry with `metadata.type ==
+  "index_event"`: `{"type": "index_event", "symbols": 7701, "files": 1180,
+  "elapsed_s": 4.29}` — matches the run's own printed summary ("7,701 symbols across
+  1,180 files").
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
@@ -15,6 +15,9 @@
   `search_episodes("zanzibar", include_archived=True)` → hit found (`e_0`, the seeded
   entry), tagged `{"archived": true}`.
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `dummy` fixture (backup/restore repeated), identical
+  seed shape and identical result — 18 live / 12 archived, 0 hits without the flag,
+  hit found and tagged archived with it.
 
 ## TC-205-2: System events land in the timeline
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy
@@ -29,3 +32,6 @@
   "elapsed_s": 4.29}` — matches the run's own printed summary ("7,701 symbols across
   1,180 files").
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `easy/fastapi` fixture (backup/restore repeated),
+  identical result — exactly 1 `index_event` episode, `{"symbols": 7701, "files": 1180,
+  "elapsed_s": 3.63}`.

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -32,9 +32,11 @@ stories:
                         # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
                         # identical results both times. PR merged 2026-08-11.
   - id: COGNIREPO-205
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-205
-    pr: null
-    test_status: not-run
+    pr: https://github.com/ashlesh-t/cognirepo/pull/51
+    test_status: pass  # automated (1354 passed, 9 skipped, +8 new) + live TC-205-1
+                        # (zanzibar archive hit found only with include_archived=True)
+                        # and TC-205-2 (index-repo logs exactly 1 index_event) — both PASS
 defects: []
 epic_test_suite_status: not-run

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 not-started
+    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 in-review (PR #51)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/data/memory/episodic_memory.py
+++ b/data/memory/episodic_memory.py
@@ -17,7 +17,7 @@ import os
 import re
 import threading
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 
 from core.config.paths import get_path
 
@@ -68,8 +68,8 @@ def _rotate_if_needed(data: list) -> list:
 
 
 # ── BM25 module-level cache ───────────────────────────────────────────────────
-# (event_id, tokenized_text) pairs built on first search; cleared on _save()
-_BM25_CORPUS: list[tuple[str, list[str]]] | None = None
+# event IDs (in _BM25_INDEX's row order) for the live-store corpus; cleared on _save()
+_BM25_CORPUS: list[str] | None = None
 _BM25_INDEX: object | None = None  # BM25Okapi instance, or None when corpus empty
 _BM25_LOCK = threading.Lock()
 
@@ -163,27 +163,51 @@ def _save(data: list) -> None:
         _BM25_INDEX = None
 
 
+def _build_bm25(data: list):
+    """Build a fresh (uncached) BM25 index over `data`. Returns (index, event_ids)."""
+    from rank_bm25 import BM25Plus  # pylint: disable=import-outside-toplevel
+    corpus: list[list[str]] = []
+    event_ids: list[str] = []
+    for entry in data:
+        text = entry.get("event", "") + " " + json.dumps(entry.get("metadata", {}))
+        corpus.append(_tokenize(text))
+        event_ids.append(entry["id"])
+
+    if not corpus:
+        return None, []
+    return BM25Plus(corpus), event_ids
+
+
 def _get_bm25(data: list):
-    """Return (BM25Okapi instance, event_id_list), building from cache if available."""
+    """Return (BM25Okapi instance, event_id_list), building from cache if available.
+
+    Caches only the live-store index — callers that merge in archived entries
+    (search_episodes(include_archived=True)) must use _build_bm25() directly so
+    an archive-inflated corpus never gets stored as the live cache.
+    """
     global _BM25_CORPUS, _BM25_INDEX  # pylint: disable=global-statement
     with _BM25_LOCK:
         if _BM25_INDEX is not None and _BM25_CORPUS is not None:
-            return _BM25_INDEX, [eid for eid, _ in _BM25_CORPUS]
+            return _BM25_INDEX, _BM25_CORPUS
 
-        from rank_bm25 import BM25Plus  # pylint: disable=import-outside-toplevel
-        corpus: list[list[str]] = []
-        event_ids: list[str] = []
-        for entry in data:
-            text = entry.get("event", "") + " " + json.dumps(entry.get("metadata", {}))
-            corpus.append(_tokenize(text))
-            event_ids.append(entry["id"])
-
-        if not corpus:
+        index, event_ids = _build_bm25(data)
+        if index is None:
             return None, []
 
-        _BM25_INDEX = BM25Plus(corpus)
-        _BM25_CORPUS = list(zip(event_ids, corpus))
+        _BM25_INDEX = index
+        _BM25_CORPUS = event_ids
         return _BM25_INDEX, event_ids
+
+
+def _load_archive() -> list:
+    apath = _archive_path()
+    if not os.path.exists(apath):
+        return []
+    try:
+        with open(apath, "rb") as f:
+            return json.loads(f.read())
+    except (OSError, json.JSONDecodeError):
+        return []
 
 
 def log_event(event: str, metadata: dict = None) -> None:
@@ -197,7 +221,7 @@ def log_event(event: str, metadata: dict = None) -> None:
         "id": _next_event_id(data),
         "event": event,
         "metadata": metadata or {},
-        "time": datetime.utcnow().isoformat() + "Z",
+        "time": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     if data:
         entry["prev"] = data[-1]["id"]
@@ -213,8 +237,47 @@ def get_history(limit: int = 100) -> list:
     return data[-limit:]
 
 
+def _vec_cache_paths() -> tuple[str, str]:
+    return get_path("memory/episodic_vecs.npy"), get_path("memory/episodic_vecs_ids.json")
+
+
+def _load_vec_cache():
+    """Return (ids, vecs) for the persisted embedding cache, or ([], None) if
+    missing/corrupt/mismatched — regenerable, so any failure just means a cold cache."""
+    vec_path, ids_path = _vec_cache_paths()
+    if not (os.path.exists(vec_path) and os.path.exists(ids_path)):
+        return [], None
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        with open(ids_path, encoding="utf-8") as f:
+            ids = json.load(f)
+        vecs = np.load(vec_path)
+        if len(ids) != vecs.shape[0]:
+            return [], None
+        return ids, vecs
+    except Exception:  # pylint: disable=broad-except
+        return [], None
+
+
+def _save_vec_cache(ids: list, vecs) -> None:
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        vec_path, ids_path = _vec_cache_paths()
+        np.save(vec_path, vecs.astype("float32"))
+        with open(ids_path, "w", encoding="utf-8") as f:
+            json.dump(ids, f)
+    except OSError:
+        pass  # cache write failure is non-fatal — regenerable from source entries
+
+
 def _semantic_episode_search(data: list, query: str, limit: int) -> list:
-    """Vector fallback for search_episodes when BM25 returns no results."""
+    """Vector fallback for search_episodes when BM25 returns no results.
+
+    Entry embeddings are cached by event ID at .cognirepo/memory/episodic_vecs.npy
+    (+ id-list sidecar) — entry text is immutable once logged (only the `stale`
+    flag mutates), so a cache hit by ID is always valid; no invalidation needed.
+    Only the query itself, and any entry not yet in the cache, get encoded.
+    """
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         from data.memory.embeddings import encode_with_timeout  # pylint: disable=import-outside-toplevel
@@ -222,13 +285,26 @@ def _semantic_episode_search(data: list, query: str, limit: int) -> list:
         q_norm = np.linalg.norm(q_vec)
         if q_norm == 0:
             return []
+
+        cached_ids, cached_vecs = _load_vec_cache()
+        cache_index = {eid: i for i, eid in enumerate(cached_ids)}
+        new_ids: list[str] = []
+        new_vecs: list = []
+
         scored = []
         for entry in data:
             text = entry.get("event", "") or str(entry.get("metadata", ""))
             if not text:
                 continue
+            eid = entry.get("id")
             try:
-                e_vec = encode_with_timeout(text[:512])
+                if eid is not None and eid in cache_index:
+                    e_vec = cached_vecs[cache_index[eid]]
+                else:
+                    e_vec = encode_with_timeout(text[:512])
+                    if eid is not None:
+                        new_ids.append(eid)
+                        new_vecs.append(e_vec)
                 e_norm = np.linalg.norm(e_vec)
                 if e_norm == 0:
                     continue
@@ -237,18 +313,37 @@ def _semantic_episode_search(data: list, query: str, limit: int) -> list:
                     scored.append((sim, entry))
             except Exception:  # pylint: disable=broad-except
                 continue
+
+        if new_ids:
+            if cached_vecs is not None and len(cached_ids):
+                merged_ids = cached_ids + new_ids
+                merged_vecs = np.vstack([cached_vecs, np.array(new_vecs, dtype="float32")])
+            else:
+                merged_ids = new_ids
+                merged_vecs = np.array(new_vecs, dtype="float32")
+            _save_vec_cache(merged_ids, merged_vecs)
+
         scored.sort(key=lambda x: x[0], reverse=True)
         return [e for _, e in scored[:limit]]
     except Exception:  # pylint: disable=broad-except
         return []
 
 
-def search_episodes(query: str, limit: int = 10) -> list:
+def search_episodes(query: str, limit: int = 10, include_archived: bool = False) -> list:
     """
     Search episodic events. BM25 (keyword) first; vector-similarity fallback
     when BM25 returns zero results (handles synonym and paraphrase mismatches).
+
+    include_archived: also search events rotated out to episodic_archive.json
+    (default False — live store only). Archived hits are tagged {"archived": True}.
     """
     data = _load()
+    archived_ids: set = set()
+    if include_archived:
+        archive = _load_archive()
+        archived_ids = {e["id"] for e in archive if "id" in e}
+        data = archive + data
+
     if not data:
         return []
 
@@ -256,7 +351,7 @@ def search_episodes(query: str, limit: int = 10) -> list:
     if not tokens:
         return []
 
-    bm25, event_ids = _get_bm25(data)
+    bm25, event_ids = _build_bm25(data) if include_archived else _get_bm25(data)
     if bm25 is None:
         return []
 
@@ -273,6 +368,11 @@ def search_episodes(query: str, limit: int = 10) -> list:
     if not results:
         results = _semantic_episode_search(data, query, limit)
 
+    if archived_ids:
+        for r in results:
+            if r.get("id") in archived_ids:
+                r["archived"] = True
+
     return results
 
 
@@ -285,8 +385,8 @@ class EpisodicMemory:  # pylint: disable=missing-function-docstring
     def get_history(self, limit: int = 100) -> list:
         return get_history(limit)
 
-    def search_episodes(self, query: str, limit: int = 10) -> list:
-        return search_episodes(query, limit)
+    def search_episodes(self, query: str, limit: int = 10, include_archived: bool = False) -> list:
+        return search_episodes(query, limit, include_archived)
 
     def mark_stale(self, file_path: str) -> int:
         return mark_stale(file_path)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,6 +89,10 @@ CogniRepo reads its configuration from `.cognirepo/config.json` in the project r
     semantic_metadata.json  ← per-vector metadata (text, source, importance, timestamp)
     episodic.json           ← append-only episodic event journal (JSON lines)
     episodic_archive.json   ← rotated events when episodic_max_events is exceeded
+    episodic_vecs.npy       ← cached entry embeddings for semantic episodic search
+                               fallback, keyed by event id (episodic_vecs_ids.json
+                               sidecar); regenerable — safe to delete
+    episodic_vecs_ids.json  ← id list, row-aligned with episodic_vecs.npy
   graph/                    ← knowledge graph
     graph.pkl               ← serialised NetworkX DiGraph
   index/                    ← AST symbol index

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -327,7 +327,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-94 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+95 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -249,13 +249,16 @@ see [USAGE.md](USAGE.md).
 
 ## episodic_search
 
-**Signature:** `episodic_search(query: str, limit: int = 10) → list[dict]`
+**Signature:** `episodic_search(query: str, limit: int = 10, include_archived: bool = False) → list[dict]`
 
-BM25-ranked keyword search in the event history.
+BM25-ranked keyword search in the event history; vector-similarity fallback when BM25
+returns zero results. `include_archived` (COGNIREPO-205) also searches events rotated
+out to `episodic_archive.json` by `episodic_max_events` rotation — default False (live
+store only). Archived hits are tagged `{"archived": true}`.
 
 **Input:**
 ```json
-{ "query": "redis cache bug", "limit": 5 }
+{ "query": "redis cache bug", "limit": 5, "include_archived": true }
 ```
 
 **Output:**
@@ -616,7 +619,8 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
     {"ts": "2026-08-08T09:00:00+00:00", "kind": "decision", "summary": "use FAISS for vector search", "ref": "e_42"},
     {"ts": "2026-08-07T14:00:00+00:00", "kind": "error", "summary": "ImportError (x3)", "ref": "ImportError"},
     {"ts": "2026-08-06T11:00:00+00:00", "kind": "session", "summary": "how does scoring work", "ref": "sess_abc123"}
-  ]
+  ],
+  "decision_nudge": "no decisions recorded yet — use record_decision for architectural choices"
 }
 ```
 
@@ -629,6 +633,17 @@ than a new MCP tool (0 manifest tokens vs. ~180 measured for a standalone
 plus the deterministic `rollup()` — counts + top decisions/errors, no model-generated
 text), call `data.memory.timeline.merge()`/`rollup()` directly, or from a future
 `generate_insights` tool (EPIC-300).
+
+**decision_nudge** (COGNIREPO-205): present only when the last 30 days have ≥5
+episodes but 0 decisions — a hint to use `record_decision` for architectural
+choices, since CLAUDE.md's instruction alone doesn't guarantee agents call it.
+Omitted from the payload entirely when there's nothing to nudge about.
+
+**Episodic events also include `index_event`-typed entries** (COGNIREPO-205):
+`cognirepo index-repo` and `cognirepo org rewire` completions are logged
+automatically (metadata `{"type": "index_event", ...}` with symbol/file or
+edge/repo counts), so infrastructure activity shows up in `recent_timeline` /
+`data.memory.timeline.merge()` even when no agent called `log_episode`.
 
 ---
 

--- a/glama.json
+++ b/glama.json
@@ -151,6 +151,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/interface/adapters/openai_tools.json
+++ b/interface/adapters/openai_tools.json
@@ -161,6 +161,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -2207,6 +2207,20 @@ def _direct_index(path, embed: bool = True, skip_graph: bool | None = None, tier
     except Exception:  # pylint: disable=broad-except
         pass  # non-fatal
 
+    try:
+        from data.memory.episodic_memory import log_event as _log_index_event  # pylint: disable=import-outside-toplevel
+        _log_index_event(
+            f"index-repo completed: {n_symbols:,} symbols across {n_files:,} files",
+            metadata={
+                "type": "index_event",
+                "symbols": n_symbols,
+                "files": n_files,
+                "elapsed_s": round(elapsed, 2),
+            },
+        )
+    except Exception:  # pylint: disable=broad-except
+        pass  # non-fatal — indexing already succeeded
+
     _write_last_indexed_sha(abs_path)
 
     # Auto-launch Tier 2 background if pending queue exists (files or embed deferred).
@@ -4216,6 +4230,14 @@ def _main():
                 finally:
                     _CTX_DIR.reset(token)
             print(f"Rewire complete — {total} CALLS_API edge(s) across {len(indexed)} indexed repo(s).")
+            try:
+                from data.memory.episodic_memory import log_event as _log_rewire_event  # pylint: disable=import-outside-toplevel
+                _log_rewire_event(
+                    f"org rewire completed: {total} edges across {len(indexed)} repos",
+                    metadata={"type": "index_event", "edges": total, "repos": len(indexed)},
+                )
+            except Exception:  # pylint: disable=broad-except
+                pass  # non-fatal — rewire already succeeded
         elif args.org_command == "graph":
             from data.graph.org_graph import get_org_graph  # pylint: disable=import-outside-toplevel
             og = get_org_graph()

--- a/interface/server/manifest.json
+++ b/interface/server/manifest.json
@@ -148,6 +148,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1519,14 +1519,22 @@ def subgraph(entity: str, depth: int = 2, repo_path: str | None = None) -> dict:
 
 
 @mcp.tool()
-def episodic_search(query: str, limit: int = 10, repo_path: str | None = None) -> list:
+def episodic_search(
+    query: str,
+    limit: int = 10,
+    include_archived: bool = False,
+    repo_path: str | None = None,
+) -> list:
     """
     Return past episodic events matching a keyword query.
 
+    include_archived: also search events rotated out of the live store
+    (episodic_archive.json). Default False — live store only. Archived hits
+    are tagged {"archived": True}.
     repo_path: optional absolute path to the target repository.
     """
     with _repo_ctx(repo_path):
-        result = search_episodes(query, limit)
+        result = search_episodes(query, limit, include_archived)
     _behaviour_record_query(query, result)
     try:
         from interface.tools.context_pack import save_query_context  # pylint: disable=import-outside-toplevel
@@ -1939,6 +1947,19 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         except Exception:  # pylint: disable=broad-except
             pass
 
+        # ── decision-coverage nudge (COGNIREPO-205) ─────────────────────────────
+        # Agents that never call record_decision leave the timeline's decision
+        # count at 0 even as episodes pile up — nudge once that gap is clear,
+        # rather than relying on CLAUDE.md instructions alone.
+        decision_nudge = ""
+        try:
+            from data.memory.timeline import merge as _nudge_merge, rollup as _nudge_rollup  # pylint: disable=import-outside-toplevel
+            _counts = _nudge_rollup(_nudge_merge(since="30d", limit=200))["counts"]
+            if _counts.get("decision", 0) == 0 and _counts.get("episode", 0) >= 5:
+                decision_nudge = "no decisions recorded yet — use record_decision for architectural choices"
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     # ── child services (orchestrator repos only) ──────────────────────────────
     child_services: list[dict] = []
     try:
@@ -1977,6 +1998,8 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
     }
     if child_services:
         result["child_services"] = child_services
+    if decision_nudge:
+        result["decision_nudge"] = decision_nudge
     return result
 
 

--- a/tests/test_episodic_205.py
+++ b/tests/test_episodic_205.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_episodic_205.py — COGNIREPO-205 acceptance criteria.
+
+1. search_episodes(include_archived=...) — archived events are searchable only
+   with the flag; default behavior (live-only) is unchanged.
+2. Persistent embedding cache for the semantic fallback — repeat searches over
+   an unchanged corpus re-encode 0 documents (only the query, if anything).
+3. index-repo logs exactly one index_event episode on a fixture repo.
+4. datetime.utcnow() deprecation removed from episodic_memory.py.
+"""
+from __future__ import annotations
+
+import json
+
+
+# ── AC1: archive search ─────────────────────────────────────────────────────
+
+class TestArchiveSearch:
+    def test_archived_hit_found_only_with_flag(self, tmp_path, monkeypatch):
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        # live store: nothing matching
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        live = [{"id": "e_1", "event": "reviewed PR", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps(live))
+
+        # archive: unique keyword
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+
+        without_flag = search_episodes("zanzibar", limit=5, include_archived=False)
+        assert without_flag == []
+
+        with_flag = search_episodes("zanzibar", limit=5, include_archived=True)
+        by_id = {r["id"]: r for r in with_flag}
+        assert "e_0" in by_id, "archived entry must be findable with include_archived=True"
+        assert by_id["e_0"]["archived"] is True
+
+    def test_live_hit_not_marked_archived(self, tmp_path, monkeypatch):
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        live = [{"id": "e_1", "event": "zanzibar deployed to prod", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps(live))
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+        results = search_episodes("zanzibar", limit=5, include_archived=True)
+        ids = {r["id"] for r in results}
+        assert ids == {"e_0", "e_1"}
+        live_result = next(r for r in results if r["id"] == "e_1")
+        assert "archived" not in live_result
+
+    def test_default_excludes_archive(self, tmp_path, monkeypatch):
+        """include_archived defaults to False — matches TC-205-1's expectation."""
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps([]))
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+        assert search_episodes("zanzibar", limit=5) == []
+
+
+# ── AC2: persistent embedding cache ──────────────────────────────────────────
+
+class TestSemanticSearchEmbeddingCache:
+    def test_second_identical_search_reencodes_no_entries(self, tmp_path, monkeypatch):
+        import numpy as np
+        import data.memory.episodic_memory as em
+
+        entries = [
+            {"id": f"e_{i}", "event": f"unique topic phrase number {i}", "metadata": {}, "time": "2026-08-01T00:00:00Z"}
+            for i in range(5)
+        ]
+
+        calls = {"n": 0}
+        rng = np.random.default_rng(42)
+        vec_by_text: dict[str, "np.ndarray"] = {}
+
+        def _fake_encode(text, timeout=None):
+            calls["n"] += 1
+            if text not in vec_by_text:
+                vec_by_text[text] = rng.random(8).astype("float32")
+            return vec_by_text[text]
+
+        monkeypatch.setattr("data.memory.embeddings.encode_with_timeout", _fake_encode)
+
+        # BM25 returns nothing for this query -> forces the semantic fallback
+        query = "zzz_no_bm25_overlap_zzz"
+
+        first = em._semantic_episode_search(entries, query, limit=5)
+        calls_after_first = calls["n"]
+        assert calls_after_first == len(entries) + 1  # 5 entries + 1 query
+
+        calls["n"] = 0
+        second = em._semantic_episode_search(entries, query, limit=5)
+        # Only the query needs encoding again — all 5 entries now cache hits.
+        assert calls["n"] == 1
+
+    def test_embedding_cache_written_to_disk_and_reloadable(self, tmp_path, monkeypatch):
+        """Cache file + id sidecar are written under .cognirepo/memory/ and reloadable."""
+        import numpy as np
+        import data.memory.episodic_memory as em
+
+        entries = [{"id": "e_0", "event": "solo cached entry", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+
+        def _fake_encode(text, timeout=None):
+            return np.ones(8, dtype="float32")
+
+        monkeypatch.setattr("data.memory.embeddings.encode_with_timeout", _fake_encode)
+        em._semantic_episode_search(entries, "anything", limit=5)
+
+        ids, vecs = em._load_vec_cache()
+        assert ids == ["e_0"]
+        assert vecs.shape == (1, 8)
+
+
+# ── AC3: system events land in the timeline ──────────────────────────────────
+
+class TestIndexEventLogging:
+    def test_index_repo_logs_exactly_one_index_event(self, tmp_path, monkeypatch):
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "hello.py").write_text("def greet(name):\n    return name\n")
+
+        from interface.cli.main import _direct_index
+        _direct_index(str(tmp_path), embed=False, skip_graph=True)
+
+        from data.memory.episodic_memory import get_history
+        index_events = [
+            e for e in get_history(limit=1000)
+            if e.get("metadata", {}).get("type") == "index_event"
+        ]
+        assert len(index_events) == 1
+        assert "symbols" in index_events[0]["metadata"]
+        assert "files" in index_events[0]["metadata"]
+
+
+# ── AC4: datetime.utcnow() removed ───────────────────────────────────────────
+
+class TestNoDeprecatedUtcnow:
+    def test_log_event_timestamp_is_tz_aware_parseable(self, tmp_path, monkeypatch):
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+        em.log_event("test event")
+
+        from datetime import datetime
+        data = em._load()
+        assert len(data) == 1
+        ts = data[0]["time"]
+        # datetime.now(timezone.utc).isoformat() with "Z" suffix must parse cleanly
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+
+    def test_no_utcnow_call_in_source(self):
+        import inspect
+        import data.memory.episodic_memory as em
+        source = inspect.getsource(em)
+        assert "datetime.utcnow()" not in source


### PR DESCRIPTION
Ticket: `JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/COGNIREPO-205.md`

## Summary
Three episodic gaps closed (`../../COGNIREPO-200-Discovery.md` §2-§3):

1. `search_episodes(query, limit, include_archived=False)` — when True, extends the
   search corpus with `episodic_archive.json` (rotated events). The BM25 module-level
   cache stays live-store-only (`_get_bm25`); archived queries build a fresh index via
   the new `_build_bm25()` so an archive-inflated corpus never pollutes the live cache.
   Archived hits are tagged `{"archived": true}`. Exposed on the `episodic_search` MCP
   tool as an additive param (+1 field in `manifest.json`, regenerated via
   `scripts/gen_tool_specs.py`).

2. Persistent embedding cache for `_semantic_episode_search`'s vector fallback —
   `.cognirepo/memory/episodic_vecs.npy` + an id-list sidecar, keyed by event ID. Entry
   text is immutable once logged (only the `stale` flag mutates), so a cache hit by ID
   is always valid — no invalidation logic needed. A second identical fallback search
   over an unchanged corpus re-encodes 0 entries, only the query itself.

3. `index-repo` and `org rewire` completions now call `log_event` with
   `{"type": "index_event", ...}` metadata (symbol/file counts, or edge/repo counts),
   so infrastructure activity shows up in COGNIREPO-204's timeline without an agent
   ever calling `log_episode`. `get_agent_bootstrap` gained a `decision_nudge` field —
   present only when the last 30 days have ≥5 episodes but 0 decisions.

Also fixed the `datetime.utcnow()` deprecation in `log_event` (AC4).

## Acceptance criteria
- [x] Archived event found only with `include_archived=True`; default behavior unchanged.
- [x] Second identical fallback search performs 0 encode calls for corpus entries
      (monkeypatched counter test — `tests/test_episodic_205.py`).
- [x] `index-repo` on a fixture adds exactly one `index_event` episode.
- [x] `datetime.utcnow()` deprecation in `episodic_memory.py` fixed.
- [x] `docs/MCP_TOOLS.md` + `docs/CONFIGURATION.md` updated for the shipped surface.

## Test plan
- `pytest tests/ -q` → **1354 passed, 9 skipped** (was 1346 before this story; 8 new
  tests in `tests/test_episodic_205.py`). `docs/FEATURES.md` test-file count bumped
  94 → 95 (`tests/test_docs_sync.py` enforces this stays in sync).
- **Live TC-205-1**: `cognirepo_test_repo/dummy` (`.cognirepo/` backed up/restored
  around the test). `episodic_max_events` set to 20, 30 events logged (event #1 has a
  unique "zanzibar" keyword), rotation triggered (18 live / 12 archived).
  `include_archived=False` → 0 hits; `include_archived=True` → hit found on the seeded
  entry, tagged `{"archived": true}`.
- **Live TC-205-2**: `cognirepo_test_repo/easy/fastapi` (`.cognirepo/` backed up/restored
  around the test). Ran the real `cognirepo index-repo .` command — episodic log
  afterward contained exactly 1 entry with `metadata.type == "index_event"`, matching
  the run's own printed summary (7,701 symbols / 1,180 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)