### PR TITLE
COGNIREPO-200: KGEpisodicHardening epic — v2.0.1 → v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ---
 
+## [Unreleased]
+
+### Added
+- **COGNIREPO-201 — knowledge graph integrity sweep + metrics.**
+  `KnowledgeGraph.integrity_report(repo_root)` reports `orphans` (FILE/FUNCTION/CLASS
+  nodes with degree 0 — restricted to these types since MEMORY/SESSION/ERROR/QUERY/
+  CONCEPT nodes are legitimately edge-free early in their lifecycle) and
+  `dangling_files` (file paths no longer on disk, deduplicated across every symbol
+  in that file), O(nodes). `graph_stats` gains an output-only `integrity` block (no
+  input-schema change); `doctor` flags nonzero orphans/dangling as a warning with a
+  repair hint. New `cognirepo graph repair [--apply]` prunes dangling file nodes via
+  `remove_file_nodes()` — dry-run by default, orphan CONCEPT stubs untouched (they
+  carry no `file` attr).
+
 ## [2.0.1] — 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-08-12
+
 ### Added
 - **COGNIREPO-201 — knowledge graph integrity sweep + metrics.**
   `KnowledgeGraph.integrity_report(repo_root)` reports `orphans` (FILE/FUNCTION/CLASS
@@ -19,6 +21,50 @@ Versioning: [Semantic Versioning](https://semver.org/)
   repair hint. New `cognirepo graph repair [--apply]` prunes dangling file nodes via
   `remove_file_nodes()` — dry-run by default, orphan CONCEPT stubs untouched (they
   carry no `file` attr).
+- **COGNIREPO-202 — SIMILAR_TO edges via FAISS k-NN at index time.** Post-index k-NN
+  pass over already-embedded FUNCTION/CLASS symbol vectors adds a `SIMILAR_TO` edge
+  (cosine ≥ 0.80, max 5/node, cross-file only) between near-duplicate symbols, in both
+  directions. Gated via `config.json` → `indexing.similarity_edges` (default on below
+  `_SIMILARITY_SYMBOL_CEILING` = 20,000 candidate symbols, off above it — k-NN cost
+  scales with candidate count; explicit config value always wins). Weighted (discounted
+  0.7x when it's the *only* link) into `intelligence/retrieval/hybrid.py::_graph_score`,
+  so a real structural edge (CALLS/DEFINED_IN/etc.) still outranks a similarity-only
+  link. Index-time overhead measured at ~4.5% on a 10,311-symbol repo.
+- **COGNIREPO-203 — Go call-graph completion + dynamic-dispatch annotation.** Fixed
+  `intelligence/indexer/ast_indexer.py::_ts_collect_calls` dropping every
+  receiver-qualified Go call (`recv.Method()`): Go's tree-sitter `selector_expression`
+  names its method field `field`, not `property` (the JS/TS convention the extractor
+  assumed) — added a field-name fallback. Also raised the call-recursion depth cap
+  12 → 60 (too shallow for realistic nested code, dropping innermost calls regardless
+  of language). Added Go `IMPORTS` edges resolved via `go.mod`. New static,
+  annotation-only dynamic-dispatch detection (`_detect_dynamic_dispatch`,
+  `_apply_entry_points_dispatch`) tags FUNCTION/CLASS symbols reachable via
+  `@task`/`@shared_task` decorators, `register(...)`-style plugin calls,
+  `__init_subclass__` hooks, and packaging entry-points with `dispatch:"dynamic"` plus
+  a `RELATES_TO` edge to a `dynamic_dispatch` CONCEPT node — never fabricates a CALLS
+  edge.
+- **COGNIREPO-204 — unified timeline (`data/memory/timeline.py`) + bootstrap digest.**
+  `merge(since, include_archived, limit)` merges episodic events (live + optionally
+  archived), session-exchange files, and behaviour-tracked error patterns into one
+  chronologically ordered view (`{ts, kind, summary, ref}`); `rollup(entries)` is a
+  deterministic template rollup (counts + top decisions/errors, no model-generated
+  text) — the data foundation for EPIC-300's insights report. Replaces the
+  `get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch an
+  agent previously had to do by hand. Folded a 5-entry digest into
+  `get_agent_bootstrap()`'s existing output (`recent_timeline`) rather than a new
+  `get_timeline` MCP tool — 0 manifest tokens vs. ~180 measured for a standalone tool.
+- **COGNIREPO-205 — episodic archive search, embedding cache, index_event logging.**
+  `search_episodes(query, limit, include_archived=False)` optionally extends the
+  search corpus with `episodic_archive.json` (rotated events); archived hits are
+  tagged `{"archived": true}`. Persistent embedding cache for the semantic-search
+  fallback (`.cognirepo/memory/episodic_vecs.npy` + id sidecar, keyed by event ID —
+  entry text is immutable once logged, so a cache hit by ID is always valid) means a
+  second identical fallback search re-encodes 0 corpus entries, only the query.
+  `index-repo` and `org rewire` completions now log an `index_event` episode
+  automatically, so infra activity shows up in the timeline without an agent calling
+  `log_episode`. `get_agent_bootstrap` gained a `decision_nudge` field (present only
+  when ≥5 episodes exist with 0 decisions in the last 30 days). Fixed the
+  `datetime.utcnow()` deprecation in `log_event`.
 
 ## [2.0.1] — 2026-07-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ milestones, `record_error()` for any errors hit. This updates the profile for ne
 | Store user's style/format preference | `record_user_preference("key", "value")` |
 | User's interaction style | `get_user_profile()` — then apply framing_hints |
 | Avoid repeating past errors | `get_error_patterns()` — check before proposing a fix |
+| "What happened recently" (sessions + episodes + decisions + errors, one merged view) | `get_agent_bootstrap()`'s `recent_timeline` field (last 5, past 7 days) — replaces the `get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch. For a custom window/rollup, call `data.memory.timeline.merge()`/`rollup()` directly |
 | Record an error that occurred | `record_error("ErrorType", "message")` |
 
 ## Org search routing (pick the right tool)

--- a/JIRA/EPIC-KGEpisodicHardening-200/COGNIREPO-200-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/COGNIREPO-200-TEST_SUITE.md
@@ -10,8 +10,16 @@
   and summarize it."
 - Expected results: single tool call returns all seeded items chronologically ordered incl.
   rotated ones; rollup mentions the decision and the recurring error; no duplicate IDs.
-- Obtained results:
-- Verdict:
+- Obtained results: test repo `cognirepo_test_repo/medium/celery` (`.cognirepo/` backed
+  up/restored around the test). `episodic_max_events` set to 20; seeded 2 sessions,
+  3 log_episode, 1 record_decision, then 20 filler events (forced rotation — the 3
+  episodes + decision, logged first, were the ones archived), then 1 recurring error
+  (`BrokerConnectionError` x2). Single `data.memory.timeline.merge(include_archived=True)`
+  call returned all 27 entries, newest first, correctly kind-labeled
+  (`{"error": 1, "episode": 23, "decision": 1, "session": 2}`), 27/27 unique refs (no
+  duplicates). `rollup()` named the decision (`"switch broker retry backoff to
+  exponential"`) and the recurring error (`"BrokerConnectionError (x2)"`).
+- Verdict: PASS
 
 ## E2E-200-2: Graph enrichment round-trip (crosses 201+202+203)
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced
@@ -22,5 +30,18 @@
   graph health stats."
 - Expected results: subgraph includes the SIMILAR_TO counterpart; who_calls lists the verified
   caller(s); graph_stats shows integrity block with 0 orphans on the fresh index.
-- Obtained results:
-- Verdict:
+- Obtained results: `cognirepo_test_repo/advanced/moby` (`.cognirepo/` backed up/restored),
+  freshly reindexed (116,532 symbols, 10,186 files, 0 orphans/dangling files per
+  `graph_stats`). `who_calls('ResolvePath')` → 4 local callers, including both of
+  TC-203-1's hand-verified pair (`CreateSecretSymlinks`, `CreateConfigSymlinks`) plus 2
+  more Windows-path callers not present in TC-203-1's 22-file subset — full-repo index
+  finds more, not fewer, callers. SIMILAR_TO: moby's 116,532 candidate symbols exceed
+  `_SIMILARITY_SYMBOL_CEILING` (20,000, `ast_indexer.py:153`) — COGNIREPO-202's cost gate
+  auto-disables k-NN similarity-edge building above that ceiling by design (moby's
+  `config.json` doesn't override `indexing.similarity_edges`), so 0 SIMILAR_TO edges exist
+  there. Not a defect — verified the SIMILAR_TO leg on `cognirepo_test_repo/medium/celery`
+  instead (10,311 symbols, under the ceiling; same fixture TC-202-1 used): `subgraph
+  ('_patch_gevent')` includes its cross-file SIMILAR_TO counterpart
+  `t/unit/concurrency/test_gevent.py::test_is_patched` (cosine weight 0.847).
+- Verdict: PASS (SIMILAR_TO leg verified on celery, not moby — moby's symbol count is
+  by-design above the auto-similarity ceiling; documented, not a defect)

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
@@ -8,5 +8,16 @@
   repair and re-check."
 - Expected results: integrity shows dangling ≥ 1 naming pattern; doctor flags it;
   `cognirepo graph repair --apply` prunes; re-run shows 0; other nodes untouched.
-- Obtained results:
-- Verdict:
+- Obtained results: Automated-equivalent coverage added and passing (unit-level, real
+  KnowledgeGraph, no mocks): `tests/test_graph.py::TestKnowledgeGraphIntegrity` (clean graph →
+  0/0; orphan restricted to FILE/FUNCTION/CLASS; dangling file detected + deduped across its
+  symbols; `--apply`-equivalent prune removes danglers only, orphan CONCEPT untouched, re-sweep
+  shows 0), `tests/test_doctor.py::TestDoctorGraphIntegrity` (seeded dangling node → doctor WARN
+  with repair hint + exit ≥1; clean graph → "0 orphans · 0 dangling files"),
+  `tests/test_graph_repair.py::TestGraphRepair` (dry-run reports without mutating; `--apply`
+  removes exactly the dangling nodes and prints the count; clean graph reports "no dangling
+  file nodes found"). Full suite: 1322 passed, 5 skipped.
+  Live MCP verification against `cognirepo_test_repo/easy` (per skill.md step 4) — left for
+  the user: restart server after `rm`-ing an indexed file with the watcher stopped, run
+  `graph_stats`/doctor/`graph repair --apply` through the MCP client itself.
+- Verdict: PASS (automated). Live retest pending.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-201/TEST/COGNIREPO-201-TEST_SUITE.md
@@ -17,7 +17,19 @@
   `tests/test_graph_repair.py::TestGraphRepair` (dry-run reports without mutating; `--apply`
   removes exactly the dangling nodes and prints the count; clean graph reports "no dangling
   file nodes found"). Full suite: 1322 passed, 5 skipped.
-  Live MCP verification against `cognirepo_test_repo/easy` (per skill.md step 4) — left for
-  the user: restart server after `rm`-ing an indexed file with the watcher stopped, run
-  `graph_stats`/doctor/`graph repair --apply` through the MCP client itself.
-- Verdict: PASS (automated). Live retest pending.
+  Live retest against `cognirepo_test_repo/easy/fastapi` (indexed, watcher confirmed not
+  running — `cognirepo list` showed no running watcher daemons) — executed 2026-08-06 via CLI
+  equivalents of the MCP tools (`graph-stats`/`doctor`/`graph repair`, same
+  `KnowledgeGraph.integrity_report()` code path graph_stats calls): baseline
+  `graph-stats`/`doctor` on the indexed repo showed 0 orphans/0 dangling (7153 nodes, 28614
+  edges). Removed `fastapi/security/utils.py` (1 indexed FUNCTION,
+  `get_authorization_scheme_param`). Re-ran `graph-stats` →
+  `integrity.dangling_files: ["fastapi/security/utils.py"]`, orphans still `[]`. `doctor` → WARN
+  "0 orphan node(s), 1 dangling file(s)" with the `cognirepo graph repair --apply` hint, exit
+  code 1. `cognirepo graph repair` (dry-run) reported the same path without mutating. `cognirepo
+  graph repair --apply` removed 2 nodes (the FILE node + its FUNCTION) across the 1 dangling
+  path. Re-ran `graph-stats`/`doctor` → 0 orphans/0 dangling, 7152 nodes/28611 edges (net -1
+  node/-3 edges — consistent with live call edges redirecting onto an unresolved CONCEPT stub
+  per COGNIREPO-D10 rather than being dropped; no other symbols touched). Restored the file via
+  `git checkout -- fastapi/security/utils.py`; working tree clean.
+- Verdict: PASS (automated + live retest).

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-202/COGNIREPO-202.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-202/COGNIREPO-202.md
@@ -29,3 +29,9 @@ docs/architecture/graph.md.
 ## Risks / notes
 - Threshold/cap (0.80/5) are initial guesses — tune; risk of CONCEPT-like noise (cf.
   PYTHON_BUILTINS filtering, knowledge_graph.py:31-66).
+
+## AC3 — measured overhead (2026-08-07)
+Test repo: `cognirepo_test_repo/medium/celery` (10,311 symbols, 444 files).
+- Gate ON (default, k-NN pass runs): 111.10s wall (1073.06s user, 969% cpu)
+- Gate OFF (`indexing.similarity_edges: false`): 106.28s wall (999.45s user, 943% cpu)
+- Overhead: ~4.5% — well under the 20% target. 4,211 SIMILAR_TO edges produced.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-202/TEST/COGNIREPO-202-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-202/TEST/COGNIREPO-202-TEST_SUITE.md
@@ -9,5 +9,11 @@
   and by what edge?"
 - Expected results: SIMILAR_TO edge present with cosine weight; unrelated functions NOT
   connected; index time delta reported by index-repo acceptable.
-- Obtained results:
-- Verdict:
+- Obtained results: Indexed cognirepo_test_repo/medium/celery (10,311 symbols, gate on). Picked
+  `celery/app/__init__.py::bugreport` / `celery/app/base.py::bugreport` (near-identical
+  docstrings/behaviour). `cognirepo subgraph "bugreport"` shows both nodes connected by
+  `SIMILAR_TO` edges in both directions, weight 0.9337 (≥ 0.80 threshold). Unrelated functions
+  in the same subgraph (e.g. `celery/bin/base.py::echo`) have no SIMILAR_TO edge to bugreport.
+  Index overhead measured at ~4.5% (gate on 111.10s vs gate off 106.28s) — see AC3 note in
+  COGNIREPO-202.md.
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/COGNIREPO-203.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/COGNIREPO-203.md
@@ -29,3 +29,25 @@ node "dynamic_dispatch". who_calls keeps its existing coverage_note behavior.
 - FIRST ACTION: check whether cognirepo_test_repo/advanced contains Go sources; if not, add a
   small Go fixture under tests/fixtures/ (TEST_SUITE marks this BLOCKED until resolved).
 - Dispatch heuristics are annotation-only — they must not fabricate CALLS edges.
+
+## Implementation notes (2026-08-08)
+- FIRST ACTION resolved: cognirepo_test_repo/advanced/moby (Docker) has 9992 real .go files —
+  no synthetic fixture needed for the live TEST_SUITE check. A hand-crafted inline fixture was
+  still added to tests/test_indexer_multilang.py (TestGoIndexing) for a deterministic,
+  version-controlled ≥10-call-site regression test per AC1/AC3.
+- Root cause of the missing Go method-call resolution: tree-sitter's Go `selector_expression`
+  names its method field `field`; the existing `_ts_collect_calls` only checked `property`
+  (the JS/TS field name), so `recv.Method()` calls were silently dropped for every Go file
+  ever indexed. Fixed with a fallback field lookup.
+- A SECOND, independent bug surfaced during live verification against moby: `_ts_collect_calls`'s
+  recursion depth cap (12) was too shallow for realistic nested code — a Go method wrapping an
+  if-statement around `append(x, Struct{Field: recv.Method()})` alone reaches depth 12-13,
+  dropping the innermost call. Raised the cap to 60. This affects call extraction for every
+  supported language, not just Go, though Go's method+conditional+composite-literal style
+  triggers it disproportionately.
+- Dynamic-dispatch heuristic added as `_detect_dynamic_dispatch()` (decorators/`register()`
+  calls/`__init_subclass__`) plus a separate post-index pass `_apply_entry_points_dispatch()`
+  for pyproject.toml/setup.cfg entry-points — both annotation-only (`dispatch:"dynamic"` +
+  `RELATES_TO` → `concept::dynamic_dispatch`), no fabricated CALLS edges (verified by test).
+- language_registry ↔ service_detect.py::_SERVICE_MARKERS already in sync for Go — no change
+  needed (confirmed per CLAUDE.md rule).

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/TEST/COGNIREPO-203-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-203/TEST/COGNIREPO-203-TEST_SUITE.md
@@ -1,22 +1,39 @@
 # COGNIREPO-203 — Manual test suite
 
 ## TC-203-1: Go caller resolution
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced — VERIFY it contains Go
-  sources first; if not, use the tests/fixtures Go fixture added by this story and note it here.
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced/moby — CONFIRMED it contains
+  real Go sources (Docker/moby, 9992 .go files); BLOCKED note resolved, no synthetic fixture
+  needed. Indexed a 22-file subset (daemon/container/) in isolation for tractable indexing time.
 - Prerequisites: story merged; repo (re)indexed.
-- What to do: hand-list the callers of one exported Go function (grep); compare who_calls.
-- Prompt: "Who calls <GoFunc>? Give file:line for each caller."
+- What to do: hand-list the callers of two exported Go methods (grep -n "\.Fn(" *.go, cross-
+  checked against enclosing func line ranges); compare against `cognirepo who-calls <Fn>`.
+- Prompt: "Who calls ResolvePath? Who calls ConfigsDirPath? Give file:line for each caller."
 - Expected results: ≥90% of the hand-verified list returned with correct locations; coverage
   note honest about the remainder.
-- Obtained results:
-- Verdict: (BLOCKED until Go-source presence in the test repo is confirmed)
+- Obtained results: Hand-verified callers — ResolvePath: {CreateSecretSymlinks (line 37),
+  CreateConfigSymlinks (line 87)}; ConfigsDirPath: {ConfigMounts (line 111), ConfigFilePath
+  (line 206)}. `who-calls ResolvePath` returned both (source:"graph"), plus the same 2 sites
+  again via the pre-existing text-scan fallback (found_via:"go_receiver_fallback", expected/
+  harmless — coverage_note fires whenever the static graph alone returns ≤2 callers).
+  `who-calls ConfigsDirPath` initially returned only ConfigFilePath (1/2) — investigation
+  found a second, independent bug: `_ts_collect_calls`'s recursion depth cap (12) was too
+  shallow for real code (a method + if-statement + `append(x, Struct{Field: recv.Method()})`
+  composite literal alone reaches depth 12-13), silently dropping the ConfigsDirPath() call
+  inside ConfigMounts's composite literal. Raised the cap to 60 (ast_indexer.py::
+  _ts_collect_calls) and confirmed both hand-verified pairs resolve via the graph after
+  reindexing. Final: 4/4 hand-verified callers resolved (100%, exceeds the 90% target).
+- Verdict: PASS
 
 ## TC-203-2: Dynamic dispatch annotation
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced (or fixture)
-- Prerequisites: as above; a celery-style task or plugin-register pattern present.
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/medium/celery
+  (examples/django/demoapp/tasks.py — real `@shared_task`-decorated functions).
+- Prerequisites: as above.
 - What to do: query the symbol via lookup_symbol/subgraph.
-- Prompt: "Look up <task_fn> — does CogniRepo know it's dynamically dispatched?"
+- Prompt: "Look up add — does CogniRepo know it's dynamically dispatched?"
 - Expected results: node carries dispatch:"dynamic"; subgraph links the dynamic_dispatch
   concept.
-- Obtained results:
-- Verdict:
+- Obtained results: `cognirepo subgraph add` on the indexed tasks.py fixture shows all 7
+  `@shared_task`-decorated functions (add, mul, xsum, count_widgets, rename_widget, error_task,
+  error_backoff_test) carrying `"dispatch": "dynamic"`, each with a `RELATES_TO` edge to a
+  `concept::dynamic_dispatch` CONCEPT node. No fabricated CALLS edges observed.
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/COGNIREPO-204.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/COGNIREPO-204.md
@@ -34,3 +34,21 @@ existing output — 0 manifest tokens. Ground Rule 3 justification either way: r
 - Session-parser extraction must not change get_session_history behavior (golden test).
 - Timestamps are ISO strings across stores — normalize defensively (some old entries may lack
   timezone suffixes).
+
+## Implementation notes (2026-08-08)
+- AC4 (requires D02 merged): already satisfied — D02 (episodic ID collision after rotation)
+  was fixed and signed off under EPIC-100's defect slot (PR #34), predating this story.
+  `_next_event_id()` already produces store-lifetime-unique refs across live+archive. No new
+  defect needed; verified by reading `data/memory/episodic_memory.py` before coding.
+- Surface decision (per the "measure both" instruction): folded a 5-entry digest into
+  `get_agent_bootstrap()`'s existing output rather than a new `get_timeline` MCP tool.
+  Measured: standalone tool draft (signature + docstring, same detail level as this ticket's
+  Description) = **180 manifest-equivalent tokens** (tiktoken cl100k_base) — in line with the
+  ticket's own ~140 estimate. Folded approach = **0 manifest tokens** (`gen_tool_specs.py
+  --check` confirms manifest.json unchanged — no new `@mcp.tool()` registered). Chose folded:
+  Ground Rule 3 justification is stronger (replaces the 3-call stitch at zero manifest cost
+  instead of ~180), and `get_agent_bootstrap` is the tool already documented as the
+  session-start entry point.
+- Full `merge()`/`rollup()` API still lives in `data/memory/timeline.py` for direct use
+  (custom `since`/`include_archived`/`limit`) and as the data foundation for EPIC-300's
+  `generate_insights` tool, per the story's background.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
@@ -19,10 +19,15 @@
   — names both the decision and the error as required. One call either way (bootstrap digest
   or a single `merge()` call — no 3-call stitch).
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `cognirepo_test_repo/dummy` fixture (backup/restore
+  repeated), same seed shape, identical result — 7/7 entries, correct kind counts,
+  `rollup()` naming both the decision and the error; bootstrap digest cap (`merge(since=
+  "7d", limit=5)`) also spot-checked, returned the 5 most-recent as designed.
 
 ## TC-204-2: Archive inclusion
-- Test repo: scratch dir (isolated `.cognirepo/`, not a checked-in test repo — avoids
-  polluting a shared fixture with a synthetic 30-event rotation).
+- Test repo: `cognirepo_test_repo/TC-204-2` (dedicated scratch fixture, isolated
+  `.cognirepo/` — not the shared `dummy` fixture, avoids polluting it with a synthetic
+  30-event rotation).
 - Prerequisites: episodic_max_events lowered to 20; 30 events logged (rotation happened).
 - What to do: query with and without include_archived.
 - Prompt: "Show the full timeline including archived history, then just the recent one."
@@ -34,3 +39,6 @@
   30 refs, 30 unique — zero duplicates, confirming D02's fix (`_next_event_id()`) holds under
   a real rotation triggered by this story's merge logic, not just the isolated D02 test suite.
 - Verdict: PASS
+- Re-verified: 2026-08-12, `cognirepo_test_repo/TC-204-2` (fresh `cognirepo setup`,
+  `episodic_max_events` set to 20, 30 events logged), identical result — 18 live /
+  30 live+archived (12 archived), 30/30 unique episode refs.

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-204/TEST/COGNIREPO-204-TEST_SUITE.md
@@ -1,22 +1,36 @@
 # COGNIREPO-204 — Manual test suite
 
 ## TC-204-1: One-call timeline
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/medium
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/dummy (medium's size made ad-hoc
+  seeding slow; dummy's `.cognirepo/` was backed up before seeding and restored after).
 - Prerequisites: story merged; seed: 2 agent sessions, 3 log_episode, 1 record_decision,
   1 record_error.
 - What to do: call the shipped surface (get_timeline or bootstrap digest).
 - Prompt: "What happened in this repo in the last 7 days? Use a single CogniRepo call."
 - Expected results: all seeded items, chronological, kinds labeled; rollup readable and
   mentions the decision; exactly one tool call needed.
-- Obtained results:
-- Verdict:
+- Obtained results: `get_agent_bootstrap()`'s `recent_timeline` (5-entry cap) correctly
+  surfaced the 5 most-recent of the 7 seeded items (the 2 older sessions fell outside the
+  cap, as designed). Calling `data.memory.timeline.merge(since="30d", limit=100)` directly
+  (the full query surface behind the digest) returned all 7 seeded entries, newest first,
+  correctly kind-labeled (3 episode, 2 session, 1 decision, 1 error). `rollup()` over those 7:
+  `{"total": 7, "counts": {"error": 1, "decision": 1, "episode": 3, "session": 2},
+  "top_decisions": ["switch session storage to SQLite"], "top_errors": ["ConnectionError (x1)"]}`
+  — names both the decision and the error as required. One call either way (bootstrap digest
+  or a single `merge()` call — no 3-call stitch).
+- Verdict: PASS
 
 ## TC-204-2: Archive inclusion
-- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/dummy
+- Test repo: scratch dir (isolated `.cognirepo/`, not a checked-in test repo — avoids
+  polluting a shared fixture with a synthetic 30-event rotation).
 - Prerequisites: episodic_max_events lowered to 20; 30 events logged (rotation happened).
 - What to do: query with and without include_archived.
 - Prompt: "Show the full timeline including archived history, then just the recent one."
 - Expected results: archived events present only in the first; counts differ accordingly; no
   duplicate IDs (D02).
-- Obtained results:
-- Verdict:
+- Obtained results: `include_archived=False` returned 18 entries (live only);
+  `include_archived=True` returned all 30 (live + archived). Checked all 30 episode `ref`
+  values (the episodic `id` field) for uniqueness across the combined live+archive set:
+  30 refs, 30 unique — zero duplicates, confirming D02's fix (`_next_event_id()`) holds under
+  a real rotation triggered by this story's merge logic, not just the isolated D02 test suite.
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
@@ -8,8 +8,13 @@
 - Prompt: "Search episodic memory for 'zanzibar', including archived history."
 - Expected results: hit found with flag on; miss (or empty) with flag off; response marks it
   archived.
-- Obtained results:
-- Verdict:
+- Obtained results: `episodic_max_events` set to 20 in `dummy/.cognirepo/config.json`
+  (backed up/restored around the test); logged 30 events, event #1 = "zanzibar migration
+  notes and rollout plan" (rotated into `episodic_archive.json` — live count 18, archive
+  count 12). `search_episodes("zanzibar", include_archived=False)` → 0 results.
+  `search_episodes("zanzibar", include_archived=True)` → hit found (`e_0`, the seeded
+  entry), tagged `{"archived": true}`.
+- Verdict: PASS
 
 ## TC-205-2: System events land in the timeline
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy
@@ -17,5 +22,10 @@
 - What to do: run `cognirepo index-repo .`; then query the timeline/episodic log.
 - Prompt: "What system/indexing events happened in this repo today?"
 - Expected results: exactly one index_event episode with file/symbol counts metadata.
-- Obtained results:
-- Verdict:
+- Obtained results: ran `cognirepo index-repo . --no-watch` against
+  `cognirepo_test_repo/easy/fastapi` (`.cognirepo/` backed up/restored around the test).
+  Episodic log after the run contained exactly 1 entry with `metadata.type ==
+  "index_event"`: `{"type": "index_event", "symbols": 7701, "files": 1180,
+  "elapsed_s": 4.29}` — matches the run's own printed summary ("7,701 symbols across
+  1,180 files").
+- Verdict: PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
+++ b/JIRA/EPIC-KGEpisodicHardening-200/STORY/COGNIREPO-205/TEST/COGNIREPO-205-TEST_SUITE.md
@@ -15,6 +15,9 @@
   `search_episodes("zanzibar", include_archived=True)` → hit found (`e_0`, the seeded
   entry), tagged `{"archived": true}`.
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `dummy` fixture (backup/restore repeated), identical
+  seed shape and identical result — 18 live / 12 archived, 0 hits without the flag,
+  hit found and tagged archived with it.
 
 ## TC-205-2: System events land in the timeline
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/easy
@@ -29,3 +32,6 @@
   "elapsed_s": 4.29}` — matches the run's own printed summary ("7,701 symbols across
   1,180 files").
 - Verdict: PASS
+- Re-verified: 2026-08-12, same `easy/fastapi` fixture (backup/restore repeated),
+  identical result — exactly 1 `index_event` episode, `{"symbols": 7701, "files": 1180,
+  "elapsed_s": 3.63}`.

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -22,10 +22,12 @@ stories:
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
                         # @shared_task, 7/7 tagged) — both PASS. PR merged 2026-08-08.
   - id: COGNIREPO-204
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-204
     pr: null
-    test_status: not-run
+    test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
+                        # (7/7 seeded entries, rollup names decision+error) and
+                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS
   - id: COGNIREPO-205
     status: not-started
     branch: story/COGNIREPO-205

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -24,7 +24,7 @@ stories:
   - id: COGNIREPO-204
     status: in-review
     branch: story/COGNIREPO-204
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/50
     test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
                         # (7/7 seeded entries, rollup names decision+error) and
                         # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -8,10 +8,11 @@ stories:
     test_status: pass  # automated (1322 passed, 5 skipped) + live TC-201-1 retest against
                         # cognirepo_test_repo/easy/fastapi, both PASS
   - id: COGNIREPO-202
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-202
-    pr: null
-    test_status: not-run
+    pr: https://github.com/ashlesh-t/cognirepo/pull/48
+    test_status: pass  # automated (1331 passed, 5 skipped, +9 new) + live TC-202-1 against
+                        # cognirepo_test_repo/medium/celery, PASS
   - id: COGNIREPO-203
     status: not-started
     branch: story/COGNIREPO-203

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -32,11 +32,12 @@ stories:
                         # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
                         # identical results both times. PR merged 2026-08-11.
   - id: COGNIREPO-205
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-205
     pr: https://github.com/ashlesh-t/cognirepo/pull/51
     test_status: pass  # automated (1354 passed, 9 skipped, +8 new) + live TC-205-1
                         # (zanzibar archive hit found only with include_archived=True)
-                        # and TC-205-2 (index-repo logs exactly 1 index_event) — both PASS
+                        # and TC-205-2 (index-repo logs exactly 1 index_event) — both PASS.
+                        # Re-verified 2026-08-12 identically. PR merged 2026-08-11.
 defects: []
 epic_test_suite_status: not-run

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -22,7 +22,7 @@ stories:
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
                         # @shared_task, 7/7 tagged) — both PASS. PR merged 2026-08-08.
   - id: COGNIREPO-204
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-204
     pr: https://github.com/ashlesh-t/cognirepo/pull/50
     test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
@@ -30,7 +30,7 @@ stories:
                         # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS.
                         # Re-verified 2026-08-12 against cognirepo_test_repo/dummy (TC-204-1)
                         # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
-                        # identical results both times.
+                        # identical results both times. PR merged 2026-08-11.
   - id: COGNIREPO-205
     status: not-started
     branch: story/COGNIREPO-205

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -27,7 +27,10 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/50
     test_status: pass  # automated (1350 passed, 5 skipped, +8 new) + live TC-204-1
                         # (7/7 seeded entries, rollup names decision+error) and
-                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS
+                        # TC-204-2 (archive toggle + D02 no-dup-IDs verified) — both PASS.
+                        # Re-verified 2026-08-12 against cognirepo_test_repo/dummy (TC-204-1)
+                        # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
+                        # identical results both times.
   - id: COGNIREPO-205
     status: not-started
     branch: story/COGNIREPO-205

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -15,10 +15,12 @@ stories:
                         # cognirepo_test_repo/medium/celery, PASS. PR merged 2026-08-08,
                         # no review comments.
   - id: COGNIREPO-203
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-203
     pr: null
-    test_status: not-run
+    test_status: pass  # automated (1342 passed, 5 skipped, +11 new) + live TC-203-1
+                        # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
+                        # @shared_task, 7/7 tagged) — both PASS
   - id: COGNIREPO-204
     status: not-started
     branch: story/COGNIREPO-204

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -1,5 +1,5 @@
 epic_id: COGNIREPO-200
-status: in-progress
+status: signed-off  # 2026-08-12, v2.1.0 — all 5 stories signed off, epic e2e suite PASS
 stories:
   - id: COGNIREPO-201
     status: signed-off
@@ -40,4 +40,8 @@ stories:
                         # and TC-205-2 (index-repo logs exactly 1 index_event) — both PASS.
                         # Re-verified 2026-08-12 identically. PR merged 2026-08-11.
 defects: []
-epic_test_suite_status: not-run
+epic_test_suite_status: pass  # E2E-200-1 (medium/celery, 27/27 unique refs, rollup names
+                               # decision+recurring error) and E2E-200-2 (advanced/moby:
+                               # who_calls 4/4+, graph_stats 0 orphans; SIMILAR_TO verified
+                               # on medium/celery instead — moby's 116,532 symbols exceed
+                               # the auto-similarity ceiling by design) — both PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -4,9 +4,9 @@ stories:
   - id: COGNIREPO-201
     status: in-review
     branch: story/COGNIREPO-201
-    pr: null
-    test_status: pass  # automated cases pass (1322 passed, 5 skipped); live E2E-100-1-style
-                        # re-verification against cognirepo_test_repo/easy left for the user
+    pr: https://github.com/ashlesh-t/cognirepo/pull/47
+    test_status: pass  # automated (1322 passed, 5 skipped) + live TC-201-1 retest against
+                        # cognirepo_test_repo/easy/fastapi, both PASS
   - id: COGNIREPO-202
     status: not-started
     branch: story/COGNIREPO-202

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -1,11 +1,12 @@
 epic_id: COGNIREPO-200
-status: not-started
+status: in-progress
 stories:
   - id: COGNIREPO-201
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-201
     pr: null
-    test_status: not-run
+    test_status: pass  # automated cases pass (1322 passed, 5 skipped); live E2E-100-1-style
+                        # re-verification against cognirepo_test_repo/easy left for the user
   - id: COGNIREPO-202
     status: not-started
     branch: story/COGNIREPO-202

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -8,11 +8,12 @@ stories:
     test_status: pass  # automated (1322 passed, 5 skipped) + live TC-201-1 retest against
                         # cognirepo_test_repo/easy/fastapi, both PASS
   - id: COGNIREPO-202
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-202
     pr: https://github.com/ashlesh-t/cognirepo/pull/48
     test_status: pass  # automated (1331 passed, 5 skipped, +9 new) + live TC-202-1 against
-                        # cognirepo_test_repo/medium/celery, PASS
+                        # cognirepo_test_repo/medium/celery, PASS. PR merged 2026-08-08,
+                        # no review comments.
   - id: COGNIREPO-203
     status: not-started
     branch: story/COGNIREPO-203

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -15,12 +15,12 @@ stories:
                         # cognirepo_test_repo/medium/celery, PASS. PR merged 2026-08-08,
                         # no review comments.
   - id: COGNIREPO-203
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-203
     pr: https://github.com/ashlesh-t/cognirepo/pull/49
     test_status: pass  # automated (1342 passed, 5 skipped, +11 new) + live TC-203-1
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
-                        # @shared_task, 7/7 tagged) — both PASS
+                        # @shared_task, 7/7 tagged) — both PASS. PR merged 2026-08-08.
   - id: COGNIREPO-204
     status: not-started
     branch: story/COGNIREPO-204

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -32,9 +32,11 @@ stories:
                         # and a fresh cognirepo_test_repo/TC-204-2 fixture (TC-204-2) —
                         # identical results both times. PR merged 2026-08-11.
   - id: COGNIREPO-205
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-205
-    pr: null
-    test_status: not-run
+    pr: https://github.com/ashlesh-t/cognirepo/pull/51
+    test_status: pass  # automated (1354 passed, 9 skipped, +8 new) + live TC-205-1
+                        # (zanzibar archive hit found only with include_archived=True)
+                        # and TC-205-2 (index-repo logs exactly 1 index_event) — both PASS
 defects: []
 epic_test_suite_status: not-run

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -17,7 +17,7 @@ stories:
   - id: COGNIREPO-203
     status: in-review
     branch: story/COGNIREPO-203
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/49
     test_status: pass  # automated (1342 passed, 5 skipped, +11 new) + live TC-203-1
                         # (moby, 4/4 hand-verified callers) and TC-203-2 (celery
                         # @shared_task, 7/7 tagged) — both PASS

--- a/JIRA/EPIC-KGEpisodicHardening-200/status.yml
+++ b/JIRA/EPIC-KGEpisodicHardening-200/status.yml
@@ -2,7 +2,7 @@ epic_id: COGNIREPO-200
 status: in-progress
 stories:
   - id: COGNIREPO-201
-    status: in-review
+    status: signed-off
     branch: story/COGNIREPO-201
     pr: https://github.com/ashlesh-t/cognirepo/pull/47
     test_status: pass  # automated (1322 passed, 5 skipped) + live TC-201-1 retest against

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,8 +8,8 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: not-started
-    blocked_by: [COGNIREPO-100]
+    status: in-progress  # COGNIREPO-201 in-review
+    blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights
     status: not-started

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201 in-review
+    status: in-progress  # COGNIREPO-201 signed-off; COGNIREPO-202 next
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 not-started
+    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 in-review (PR #51)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201 signed-off; COGNIREPO-202 in-review (PR #48)
+    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 next
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 in-review (PR #51)
+    status: in-progress  # COGNIREPO-201..205 all signed-off; epic_test_suite_status: not-run
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201 signed-off; COGNIREPO-202 next
+    status: in-progress  # COGNIREPO-201 signed-off; COGNIREPO-202 in-review (PR #48)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 in-review (PR #50)
+    status: in-progress  # COGNIREPO-201..204 signed-off; COGNIREPO-205 not-started
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -1,6 +1,6 @@
 # Root JIRA registry — read this FIRST in any new session (see /skill.md).
 project: cognirepo
-active_epic: COGNIREPO-200
+active_epic: COGNIREPO-300
 epics:
   - id: COGNIREPO-100
     name: ReliabilityGate
@@ -8,20 +8,20 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201..205 all signed-off; epic_test_suite_status: not-run
+    status: signed-off  # 2026-08-12, v2.1.0 — all 5 stories + epic e2e suite PASS
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights
     status: not-started
-    blocked_by: [COGNIREPO-200]
+    blocked_by: []
   - id: COGNIREPO-400
     name: MoodPersonaLayer
     status: not-started
-    blocked_by: [COGNIREPO-200]
+    blocked_by: []
   - id: COGNIREPO-500
     name: SubagentEnrichment
     status: not-started
-    blocked_by: [COGNIREPO-200]
+    blocked_by: []
   - id: COGNIREPO-600
     name: OSSGrowth
     status: not-started

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 next
+    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 in-review (PR #50)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 in-review (PR #49)
+    status: in-progress  # COGNIREPO-201, -202, -203 signed-off; COGNIREPO-204 next
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -8,7 +8,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-200
     name: KGEpisodicHardening
-    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 next
+    status: in-progress  # COGNIREPO-201, -202 signed-off; COGNIREPO-203 in-review (PR #49)
     blocked_by: []
   - id: COGNIREPO-300
     name: RepoInsights

--- a/README.md
+++ b/README.md
@@ -612,14 +612,32 @@ Priorities drawn from the v0.3.0 benchmark findings and community feedback. Now 
 some items below have since landed; each is annotated where that's the case.
 
 ### Near-term
-- **Go call-graph indexing** — *partially done:* Go IMPORTS edges (via `go.mod` scanning) and Go symbol/class indexing (tree-sitter `function_declaration`/`type_spec`) are implemented. Go-aware `who_calls`/CALLS edges are still missing — `_extract_calls()` (`intelligence/indexer/ast_indexer.py`) only walks Python's stdlib `ast`, not tree-sitter nodes, so Moby/Kubernetes call-graph tests (MO-3-5, K8-*) remain unblocked-but-incomplete for this specific edge type.
+- **Go call-graph indexing** — *done (COGNIREPO-203):* Go receiver-qualified method calls
+  (`recv.Method()`) now resolve through `who_calls`/CALLS edges — tree-sitter's Go
+  `selector_expression` names its method field `field`, not `property` (the JS convention the
+  extractor previously assumed), so method calls were silently dropped; fixed in
+  `_ts_collect_calls` (`intelligence/indexer/ast_indexer.py`). A second bug in the same
+  function — a call-collection recursion depth cap of 12, too shallow for a Go method wrapping
+  an if-statement around a composite-literal call argument — was also raised (to 60). Go
+  IMPORTS edges from `go.mod`-resolved local package imports are implemented
+  (`_extract_imports_go`/`_resolve_go_import_to_file`). Live-verified against
+  `cognirepo_test_repo/advanced/moby`: 4/4 hand-verified callers resolved (100%, vs. the 90%
+  target) after both fixes.
 - **`cognirepo ask`** — *done:* multi-model orchestrator (QUICK/STANDARD/COMPLEX/EXPERT tiers) is implemented and wired as a real CLI command (`_cmd_ask_local`, `interface/cli/main.py`). Streaming REPL mode (see Longer-term) is not yet built.
 - **Incremental re-index on save** — *done:* the file-watcher daemon (`cognirepo watch`) debounces writes (`config.json` → `indexing.debounce_ms`, default 500ms) and batches indexer/graph saves; `tests/test_watcher_debounce.py` covers this including flush-on-shutdown.
 - **CLAUDE.md mandatory-call relaxation** — benchmark feedback (Moby tests) flagged that forcing `context_pack` before every file read adds latency under memory pressure. A `--fast` mode that skips the tool-first gate for files under 50 lines is not yet implemented.
 
 ### Medium-term
 - **Kubernetes / 2M-LOC scale validation** — K8-1 through K8-5 test suite not yet completed. Goal: full scheduling-decision trace at < 8 000 tokens with CogniRepo vs. > 50 000 without.
-- **Plugin-registry pattern detection** — Ansible AN-3/AN-4 (22-level variable precedence, strategy plugins) and Celery CE-3 (dynamic dispatch) returned NA. Plan: static heuristic pass that detects `register`, `entry_points`, and `__init_subclass__` patterns and annotates them as `DYNAMIC_DISPATCH` nodes in the graph.
+- **Plugin-registry pattern detection** — *done (COGNIREPO-203):* a static, annotation-only
+  heuristic pass tags symbols reachable via dynamic dispatch — celery-style `@task`/
+  `@shared_task` decorators, `register(...)`-style plugin-registration calls, Python
+  `__init_subclass__` hooks, and packaging entry-points (`pyproject.toml`
+  `[project.entry-points.*]` / `setup.cfg` `[options.entry_points]`) — with `dispatch:"dynamic"`
+  plus a `RELATES_TO` edge to a `dynamic_dispatch` CONCEPT node (`_detect_dynamic_dispatch`,
+  `_apply_entry_points_dispatch` in `intelligence/indexer/ast_indexer.py`). Annotation-only by
+  design — never fabricates a CALLS edge. Live-verified against
+  `cognirepo_test_repo/medium/celery`'s real `@shared_task` functions.
 - **BM25 over symbol names** — *partially done:* `core/_bm25.py` is used by `intelligence/retrieval/hybrid.py` as the circuit-breaker fallback ranker (and by episodic search) when embeddings are unavailable, but it isn't yet the primary ranking signal for symbol-name partial-match recall (e.g. `HttpClient` matching `http_client`) in the normal (embeddings-available) retrieval path.
 - **Cross-session memory warm-up** — Ansible benchmark noted episodic/memory retrieval is low-value on fresh sessions. `cognirepo prime` exists but is not run automatically on `init`; will make it opt-in default.
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ some items below have since landed; each is annotated where that's the case.
 ### Longer-term
 - **`cognirepo ask` streaming REPL** — full interactive session with tier routing, session persistence, and sub-agent delegation.
 - **Ruby, PHP, C#, Swift grammar support** — tree-sitter grammars exist; need `_TS_FUNCTION_TYPES`/`_TS_CLASS_TYPES` mappings and call-extraction rules per language.
-- **Similarity edges in knowledge graph** — embedding-distance clustering to connect semantically related symbols across files (not yet implemented).
+- **Similarity edges in knowledge graph** — *done (COGNIREPO-202):* post-index FAISS k-NN pass over already-embedded FUNCTION/CLASS symbol vectors adds a `SIMILAR_TO` edge (cosine ≥ 0.80, max 5/node, cross-file only) between near-duplicate symbols, both directions. Gated via `config.json` → `indexing.similarity_edges` (default on below 20k candidate symbols). Weighted (discounted) into `intelligence/retrieval/hybrid.py::_graph_score`.
 - **VS Code / JetBrains extension** — surface `lookup_symbol`, `context_pack`, and `who_calls` directly in the editor sidebar without requiring an MCP-capable host.
 
 ---

--- a/data/graph/knowledge_graph.py
+++ b/data/graph/knowledge_graph.py
@@ -483,3 +483,50 @@ class KnowledgeGraph:
             "nodes": self.G.number_of_nodes(),
             "edges": self.G.number_of_edges(),
         }
+
+    # ── integrity ─────────────────────────────────────────────────────────────
+
+    _ORPHAN_TYPES = (NodeType.FILE, NodeType.FUNCTION, NodeType.CLASS)
+
+    def integrity_report(self, repo_root: str) -> dict:
+        """Structural + on-disk integrity sweep. O(nodes) — safe to run on every
+        graph_stats call (AC4: < 1s on a medium repo).
+
+        orphans        : FILE/FUNCTION/CLASS node IDs with degree 0. Restricted to
+                          these types — MEMORY/SESSION/ERROR/QUERY/USER_ACTION/CONCEPT
+                          nodes are legitimately edge-free early in their lifecycle.
+        dangling_files : unique file paths (FILE node IDs, or FUNCTION/CLASS nodes'
+                          'file' attr) that no longer exist under repo_root — left
+                          behind when a file is deleted outside a live watcher/server
+                          (COGNIREPO-100-Discovery §3/§4).
+        swept_at       : ISO-8601 UTC timestamp of this sweep.
+
+        See COGNIREPO-201.
+        """
+        orphans = [
+            n for n, d in self.G.nodes(data=True)
+            if d.get("type") in self._ORPHAN_TYPES and self.G.degree(n) == 0
+        ]
+
+        dangling: list[str] = []
+        checked: set[str] = set()
+        for n, d in self.G.nodes(data=True):
+            ntype = d.get("type")
+            if ntype == NodeType.FILE:
+                rel = n
+            elif ntype in (NodeType.FUNCTION, NodeType.CLASS):
+                rel = d.get("file")
+            else:
+                continue
+            if not rel or rel in checked:
+                continue
+            checked.add(rel)
+            if not os.path.exists(os.path.join(repo_root, rel)):
+                dangling.append(rel)
+
+        from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+        return {
+            "orphans": orphans,
+            "dangling_files": dangling,
+            "swept_at": datetime.now(tz=timezone.utc).isoformat(),
+        }

--- a/data/graph/knowledge_graph.py
+++ b/data/graph/knowledge_graph.py
@@ -100,6 +100,7 @@ class EdgeType:  # pylint: disable=too-few-public-methods
     INHERITS = "INHERITS"      # class A inherits from class B
     EXPOSES = "EXPOSES"        # function → ENDPOINT node (this function handles this route)
     CALLS_ENDPOINT = "CALLS_ENDPOINT"  # caller function → remote ENDPOINT stub (cross-service)
+    SIMILAR_TO = "SIMILAR_TO"  # embedding-distance near-duplicate symbols (added both directions)
 
 
 class KnowledgeGraph:

--- a/data/memory/episodic_memory.py
+++ b/data/memory/episodic_memory.py
@@ -17,7 +17,7 @@ import os
 import re
 import threading
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 
 from core.config.paths import get_path
 
@@ -68,8 +68,8 @@ def _rotate_if_needed(data: list) -> list:
 
 
 # ── BM25 module-level cache ───────────────────────────────────────────────────
-# (event_id, tokenized_text) pairs built on first search; cleared on _save()
-_BM25_CORPUS: list[tuple[str, list[str]]] | None = None
+# event IDs (in _BM25_INDEX's row order) for the live-store corpus; cleared on _save()
+_BM25_CORPUS: list[str] | None = None
 _BM25_INDEX: object | None = None  # BM25Okapi instance, or None when corpus empty
 _BM25_LOCK = threading.Lock()
 
@@ -163,27 +163,51 @@ def _save(data: list) -> None:
         _BM25_INDEX = None
 
 
+def _build_bm25(data: list):
+    """Build a fresh (uncached) BM25 index over `data`. Returns (index, event_ids)."""
+    from rank_bm25 import BM25Plus  # pylint: disable=import-outside-toplevel
+    corpus: list[list[str]] = []
+    event_ids: list[str] = []
+    for entry in data:
+        text = entry.get("event", "") + " " + json.dumps(entry.get("metadata", {}))
+        corpus.append(_tokenize(text))
+        event_ids.append(entry["id"])
+
+    if not corpus:
+        return None, []
+    return BM25Plus(corpus), event_ids
+
+
 def _get_bm25(data: list):
-    """Return (BM25Okapi instance, event_id_list), building from cache if available."""
+    """Return (BM25Okapi instance, event_id_list), building from cache if available.
+
+    Caches only the live-store index — callers that merge in archived entries
+    (search_episodes(include_archived=True)) must use _build_bm25() directly so
+    an archive-inflated corpus never gets stored as the live cache.
+    """
     global _BM25_CORPUS, _BM25_INDEX  # pylint: disable=global-statement
     with _BM25_LOCK:
         if _BM25_INDEX is not None and _BM25_CORPUS is not None:
-            return _BM25_INDEX, [eid for eid, _ in _BM25_CORPUS]
+            return _BM25_INDEX, _BM25_CORPUS
 
-        from rank_bm25 import BM25Plus  # pylint: disable=import-outside-toplevel
-        corpus: list[list[str]] = []
-        event_ids: list[str] = []
-        for entry in data:
-            text = entry.get("event", "") + " " + json.dumps(entry.get("metadata", {}))
-            corpus.append(_tokenize(text))
-            event_ids.append(entry["id"])
-
-        if not corpus:
+        index, event_ids = _build_bm25(data)
+        if index is None:
             return None, []
 
-        _BM25_INDEX = BM25Plus(corpus)
-        _BM25_CORPUS = list(zip(event_ids, corpus))
+        _BM25_INDEX = index
+        _BM25_CORPUS = event_ids
         return _BM25_INDEX, event_ids
+
+
+def _load_archive() -> list:
+    apath = _archive_path()
+    if not os.path.exists(apath):
+        return []
+    try:
+        with open(apath, "rb") as f:
+            return json.loads(f.read())
+    except (OSError, json.JSONDecodeError):
+        return []
 
 
 def log_event(event: str, metadata: dict = None) -> None:
@@ -197,7 +221,7 @@ def log_event(event: str, metadata: dict = None) -> None:
         "id": _next_event_id(data),
         "event": event,
         "metadata": metadata or {},
-        "time": datetime.utcnow().isoformat() + "Z",
+        "time": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     if data:
         entry["prev"] = data[-1]["id"]
@@ -213,8 +237,47 @@ def get_history(limit: int = 100) -> list:
     return data[-limit:]
 
 
+def _vec_cache_paths() -> tuple[str, str]:
+    return get_path("memory/episodic_vecs.npy"), get_path("memory/episodic_vecs_ids.json")
+
+
+def _load_vec_cache():
+    """Return (ids, vecs) for the persisted embedding cache, or ([], None) if
+    missing/corrupt/mismatched — regenerable, so any failure just means a cold cache."""
+    vec_path, ids_path = _vec_cache_paths()
+    if not (os.path.exists(vec_path) and os.path.exists(ids_path)):
+        return [], None
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        with open(ids_path, encoding="utf-8") as f:
+            ids = json.load(f)
+        vecs = np.load(vec_path)
+        if len(ids) != vecs.shape[0]:
+            return [], None
+        return ids, vecs
+    except Exception:  # pylint: disable=broad-except
+        return [], None
+
+
+def _save_vec_cache(ids: list, vecs) -> None:
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        vec_path, ids_path = _vec_cache_paths()
+        np.save(vec_path, vecs.astype("float32"))
+        with open(ids_path, "w", encoding="utf-8") as f:
+            json.dump(ids, f)
+    except OSError:
+        pass  # cache write failure is non-fatal — regenerable from source entries
+
+
 def _semantic_episode_search(data: list, query: str, limit: int) -> list:
-    """Vector fallback for search_episodes when BM25 returns no results."""
+    """Vector fallback for search_episodes when BM25 returns no results.
+
+    Entry embeddings are cached by event ID at .cognirepo/memory/episodic_vecs.npy
+    (+ id-list sidecar) — entry text is immutable once logged (only the `stale`
+    flag mutates), so a cache hit by ID is always valid; no invalidation needed.
+    Only the query itself, and any entry not yet in the cache, get encoded.
+    """
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         from data.memory.embeddings import encode_with_timeout  # pylint: disable=import-outside-toplevel
@@ -222,13 +285,26 @@ def _semantic_episode_search(data: list, query: str, limit: int) -> list:
         q_norm = np.linalg.norm(q_vec)
         if q_norm == 0:
             return []
+
+        cached_ids, cached_vecs = _load_vec_cache()
+        cache_index = {eid: i for i, eid in enumerate(cached_ids)}
+        new_ids: list[str] = []
+        new_vecs: list = []
+
         scored = []
         for entry in data:
             text = entry.get("event", "") or str(entry.get("metadata", ""))
             if not text:
                 continue
+            eid = entry.get("id")
             try:
-                e_vec = encode_with_timeout(text[:512])
+                if eid is not None and eid in cache_index:
+                    e_vec = cached_vecs[cache_index[eid]]
+                else:
+                    e_vec = encode_with_timeout(text[:512])
+                    if eid is not None:
+                        new_ids.append(eid)
+                        new_vecs.append(e_vec)
                 e_norm = np.linalg.norm(e_vec)
                 if e_norm == 0:
                     continue
@@ -237,18 +313,37 @@ def _semantic_episode_search(data: list, query: str, limit: int) -> list:
                     scored.append((sim, entry))
             except Exception:  # pylint: disable=broad-except
                 continue
+
+        if new_ids:
+            if cached_vecs is not None and len(cached_ids):
+                merged_ids = cached_ids + new_ids
+                merged_vecs = np.vstack([cached_vecs, np.array(new_vecs, dtype="float32")])
+            else:
+                merged_ids = new_ids
+                merged_vecs = np.array(new_vecs, dtype="float32")
+            _save_vec_cache(merged_ids, merged_vecs)
+
         scored.sort(key=lambda x: x[0], reverse=True)
         return [e for _, e in scored[:limit]]
     except Exception:  # pylint: disable=broad-except
         return []
 
 
-def search_episodes(query: str, limit: int = 10) -> list:
+def search_episodes(query: str, limit: int = 10, include_archived: bool = False) -> list:
     """
     Search episodic events. BM25 (keyword) first; vector-similarity fallback
     when BM25 returns zero results (handles synonym and paraphrase mismatches).
+
+    include_archived: also search events rotated out to episodic_archive.json
+    (default False — live store only). Archived hits are tagged {"archived": True}.
     """
     data = _load()
+    archived_ids: set = set()
+    if include_archived:
+        archive = _load_archive()
+        archived_ids = {e["id"] for e in archive if "id" in e}
+        data = archive + data
+
     if not data:
         return []
 
@@ -256,7 +351,7 @@ def search_episodes(query: str, limit: int = 10) -> list:
     if not tokens:
         return []
 
-    bm25, event_ids = _get_bm25(data)
+    bm25, event_ids = _build_bm25(data) if include_archived else _get_bm25(data)
     if bm25 is None:
         return []
 
@@ -273,6 +368,11 @@ def search_episodes(query: str, limit: int = 10) -> list:
     if not results:
         results = _semantic_episode_search(data, query, limit)
 
+    if archived_ids:
+        for r in results:
+            if r.get("id") in archived_ids:
+                r["archived"] = True
+
     return results
 
 
@@ -285,8 +385,8 @@ class EpisodicMemory:  # pylint: disable=missing-function-docstring
     def get_history(self, limit: int = 100) -> list:
         return get_history(limit)
 
-    def search_episodes(self, query: str, limit: int = 10) -> list:
-        return search_episodes(query, limit)
+    def search_episodes(self, query: str, limit: int = 10, include_archived: bool = False) -> list:
+        return search_episodes(query, limit, include_archived)
 
     def mark_stale(self, file_path: str) -> int:
         return mark_stale(file_path)

--- a/data/memory/timeline.py
+++ b/data/memory/timeline.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+data/memory/timeline.py — COGNIREPO-204 unified timeline.
+
+Merges three independently-written stores — episodic events (log_episode/
+record_decision), session-exchange files (session_listener), and behaviour-tracked
+error patterns — into one chronologically ordered view, plus a deterministic
+template rollup (counts + top items; no model-generated text).
+
+Replaces the get_session_history + episodic_search + get_error_patterns 3-call
+stitch an agent previously had to do by hand to answer "what happened".
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+from datetime import datetime, timedelta, timezone
+
+from core.config.paths import get_path
+from data.memory.episodic_memory import _archive_path, _load as _load_episodic
+
+_EPOCH = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _parse_ts(raw: "str | None") -> datetime:
+    """Normalize an ISO timestamp string for sorting/filtering.
+
+    Some older entries lack a timezone suffix — treat those as UTC so they sort
+    consistently against tz-aware entries instead of raising on comparison.
+    Unparseable/missing timestamps sort first (oldest), not raise.
+    """
+    if not raw:
+        return _EPOCH
+    try:
+        s = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return _EPOCH
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _parse_since(since: "str | None") -> datetime:
+    """Parse a relative duration ("7d", "24h", "30m") or an ISO timestamp.
+    Falls back to 7 days ago on anything unparseable.
+    """
+    now = _now()
+    if not since:
+        return now - timedelta(days=7)
+    m = re.match(r"^(\d+)([dhm])$", since.strip())
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {"d": timedelta(days=n), "h": timedelta(hours=n), "m": timedelta(minutes=n)}[unit]
+        return now - delta
+    parsed = _parse_ts(since)
+    return parsed if parsed is not _EPOCH else now - timedelta(days=7)
+
+
+def parse_session_file(path: str) -> "dict | None":
+    """Extract session_id/created_at/message_count/last_exchange from one session
+    JSON file.
+
+    Shared by get_session_history (interface/server/mcp_server.py) and the
+    timeline merge — extracted here so both read one implementation instead of
+    two independently-maintained copies of the same last-exchange parsing.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    messages = data.get("messages", [])
+    last_exchange: dict = {}
+    for i in range(len(messages) - 1, -1, -1):
+        if messages[i].get("role") == "assistant":
+            last_exchange["assistant"] = messages[i].get("content", "")[:300]
+        elif messages[i].get("role") == "user" and "assistant" in last_exchange:
+            last_exchange["user"] = messages[i].get("content", "")[:300]
+            break
+    return {
+        "session_id": data.get("session_id", os.path.basename(path)),
+        "created_at": data.get("created_at"),
+        "message_count": len(messages),
+        "model": data.get("model", "unknown"),
+        "last_exchange": last_exchange,
+    }
+
+
+def _list_session_files() -> list[str]:
+    sessions_dir = get_path("sessions")
+    if not os.path.isdir(sessions_dir):
+        return []
+    files = glob.glob(os.path.join(sessions_dir, "*.json"))
+    return [f for f in files if not f.endswith("current.json")]
+
+
+def _session_entries() -> list[dict]:
+    entries = []
+    for sf in sorted(_list_session_files()):  # fixed disk-order input for determinism
+        parsed = parse_session_file(sf)
+        if parsed is None or not parsed.get("created_at"):
+            continue
+        exch = parsed.get("last_exchange", {})
+        summary = exch.get("user") or exch.get("assistant") or f"{parsed['message_count']} messages"
+        entries.append({
+            "ts": parsed["created_at"],
+            "kind": "session",
+            "summary": summary[:160],
+            "ref": parsed["session_id"],
+        })
+    return entries
+
+
+def _episodic_entries(include_archived: bool) -> list[dict]:
+    data = list(_load_episodic())
+    if include_archived:
+        apath = _archive_path()
+        if os.path.exists(apath):
+            try:
+                with open(apath, "rb") as f:
+                    data = json.loads(f.read()) + data
+            except (OSError, json.JSONDecodeError):
+                pass
+    entries = []
+    for e in data:
+        meta = e.get("metadata", {}) or {}
+        kind = "decision" if meta.get("type") == "decision" else "episode"
+        summary = meta.get("summary") or e.get("event", "")
+        entries.append({
+            "ts": e.get("time"),
+            "kind": kind,
+            "summary": summary[:160],
+            "ref": e.get("id", ""),
+        })
+    return entries
+
+
+def _error_entries() -> list[dict]:
+    try:
+        from data.graph.knowledge_graph import KnowledgeGraph  # pylint: disable=import-outside-toplevel
+        from data.graph.behaviour_tracker import BehaviourTracker  # pylint: disable=import-outside-toplevel
+        patterns = BehaviourTracker(KnowledgeGraph()).get_error_patterns(min_count=1)
+    except Exception:  # pylint: disable=broad-except
+        return []
+    return [
+        {
+            "ts": p.get("last_seen"),
+            "kind": "error",
+            "summary": f"{p['error_type']} (x{p['count']})",
+            "ref": p["error_type"],
+        }
+        for p in patterns
+        if p.get("last_seen")
+    ]
+
+
+def merge(since: str = "7d", include_archived: bool = False, limit: int = 100) -> list[dict]:
+    """Return timeline entries — {ts, kind, summary, ref} — newest first.
+
+    kind is one of: session, episode, decision, error. Entries older than
+    `since` (a relative duration like "7d"/"24h"/"30m", or an ISO timestamp)
+    are excluded. Deterministic: sorts by (timestamp desc, kind, ref) so ties
+    (equal or missing timestamps) always resolve the same way for identical
+    store state — required for byte-identical output (AC3).
+    """
+    cutoff = _parse_since(since)
+    raw = _session_entries() + _episodic_entries(include_archived) + _error_entries()
+    dated = [(e, _parse_ts(e.get("ts"))) for e in raw]
+    dated = [(e, dt) for e, dt in dated if dt >= cutoff]
+    dated.sort(key=lambda pair: (pair[1], pair[0]["kind"], pair[0]["ref"]), reverse=True)
+    return [e for e, _ in dated[:limit]]
+
+
+def rollup(entries: list[dict]) -> dict:
+    """Deterministic template rollup over merge() output — counts + top items,
+    no model-generated text. Foundation for EPIC-300's insights report.
+    """
+    counts: dict[str, int] = {}
+    decisions: list[str] = []
+    errors: list[str] = []
+    for e in entries:
+        counts[e["kind"]] = counts.get(e["kind"], 0) + 1
+        if e["kind"] == "decision":
+            decisions.append(e["summary"])
+        elif e["kind"] == "error":
+            errors.append(e["summary"])
+    return {
+        "total": len(entries),
+        "counts": counts,
+        "top_decisions": decisions[:3],
+        "top_errors": errors[:3],
+    }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,6 +89,10 @@ CogniRepo reads its configuration from `.cognirepo/config.json` in the project r
     semantic_metadata.json  ← per-vector metadata (text, source, importance, timestamp)
     episodic.json           ← append-only episodic event journal (JSON lines)
     episodic_archive.json   ← rotated events when episodic_max_events is exceeded
+    episodic_vecs.npy       ← cached entry embeddings for semantic episodic search
+                               fallback, keyed by event id (episodic_vecs_ids.json
+                               sidecar); regenerable — safe to delete
+    episodic_vecs_ids.json  ← id list, row-aligned with episodic_vecs.npy
   graph/                    ← knowledge graph
     graph.pkl               ← serialised NetworkX DiGraph
   index/                    ← AST symbol index

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -327,7 +327,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-94 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+95 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -85,6 +85,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 | `stats()` | ✅ | Count by node type + total edges |
 | Behaviour tracking | ✅ | `data/graph/behaviour_tracker.py` — access frequency per node |
 | Entity extraction from text | ✅ | `data/graph/graph_utils.py::extract_entities_from_text()` |
+| `SIMILAR_TO` edges (embedding-distance near-duplicates, cross-file) | ✅ | Post-index FAISS k-NN pass, `intelligence/indexer/ast_indexer.py::_build_similarity_edges()` — gated via `config.json` → `indexing.similarity_edges` |
 
 ---
 
@@ -325,7 +326,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-92 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+93 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,7 +20,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 | `log_episode(event, metadata)` | ✅ | `data/memory/episodic_memory.py::log_event()` | Append-only JSONL with timestamp chain |
 | `search_docs(query)` | ✅ | `intelligence/retrieval/docs_search.py` | Full-text search over all `.md` files, returns file+line+snippet |
 | `episodic_search(query, limit)` | ✅ | `data/memory/episodic_memory.py::search_episodes()` | BM25Okapi ranked; module-level corpus cache with TTL |
-| `graph_stats()` | ✅ | `interface/server/mcp_server.py` → `KnowledgeGraph.stats()` | Node count by type, edge count |
+| `graph_stats()` | ✅ | `interface/server/mcp_server.py` → `KnowledgeGraph.stats()` + `integrity_report()` | Node/edge counts, index freshness, integrity (orphans, dangling_files, swept_at) |
 | `semantic_search_code(query, language, top_k)` | ✅ | `interface/tools/semantic_search_code.py` | FAISS search filtered to code-type entries; language filter optional |
 | `dependency_graph(file_path)` | ✅ | `interface/tools/dependency_graph.py` | Returns imports-from + imported-by using knowledge graph edges |
 | `explain_change(file_path, before, after)` | ✅ | `interface/tools/explain_change.py` | Diff analysis using `difflib`; identifies added/removed symbols |
@@ -325,9 +325,9 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-91 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+92 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
-`tests/` for the full list. The 89-file count is pinned against `tests/test_docs_sync.py`,
+`tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.
 
 | Test File | What it Covers |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -327,7 +327,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-93 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+94 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -86,6 +86,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 | Behaviour tracking | ✅ | `data/graph/behaviour_tracker.py` — access frequency per node |
 | Entity extraction from text | ✅ | `data/graph/graph_utils.py::extract_entities_from_text()` |
 | `SIMILAR_TO` edges (embedding-distance near-duplicates, cross-file) | ✅ | Post-index FAISS k-NN pass, `intelligence/indexer/ast_indexer.py::_build_similarity_edges()` — gated via `config.json` → `indexing.similarity_edges` |
+| `dispatch:"dynamic"` annotation (celery tasks, plugin `register()`, `__init_subclass__`, packaging entry-points) | ✅ | `intelligence/indexer/ast_indexer.py::_detect_dynamic_dispatch()` / `_apply_entry_points_dispatch()` — annotation-only, `RELATES_TO` edge to `concept::dynamic_dispatch` |
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -611,9 +611,24 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
   "last_focus": {"files": ["retrieval/hybrid.py"], "query": "how does scoring work", "agent": "claude"},
   "framing": {"depth": "detailed", "vocabulary": ["retrieval", "faiss", "hybrid"], "hints": "prefers detailed responses; often asks 'how' questions; domain vocabulary: retrieval, faiss, hybrid"},
   "error_patterns": [{"type": "OOM", "count": 2, "prevention_hint": "Check RSS before loading large index"}],
-  "index_health": {"symbols": 1240, "files": 92, "status": "ok"}
+  "index_health": {"symbols": 1240, "files": 92, "status": "ok"},
+  "recent_timeline": [
+    {"ts": "2026-08-08T09:00:00+00:00", "kind": "decision", "summary": "use FAISS for vector search", "ref": "e_42"},
+    {"ts": "2026-08-07T14:00:00+00:00", "kind": "error", "summary": "ImportError (x3)", "ref": "ImportError"},
+    {"ts": "2026-08-06T11:00:00+00:00", "kind": "session", "summary": "how does scoring work", "ref": "sess_abc123"}
+  ]
 }
 ```
+
+**recent_timeline** (COGNIREPO-204): last 5 entries from the past 7 days, merged
+chronologically across sessions, episodes, decisions, and errors — replaces the
+`get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch for a
+quick "what happened recently" view. Folded into this tool's existing output rather
+than a new MCP tool (0 manifest tokens vs. ~180 measured for a standalone
+`get_timeline` tool). For the full query surface (`since`/`include_archived`/`limit`,
+plus the deterministic `rollup()` — counts + top decisions/errors, no model-generated
+text), call `data.memory.timeline.merge()`/`rollup()` directly, or from a future
+`generate_insights` tool (EPIC-300).
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -249,13 +249,16 @@ see [USAGE.md](USAGE.md).
 
 ## episodic_search
 
-**Signature:** `episodic_search(query: str, limit: int = 10) → list[dict]`
+**Signature:** `episodic_search(query: str, limit: int = 10, include_archived: bool = False) → list[dict]`
 
-BM25-ranked keyword search in the event history.
+BM25-ranked keyword search in the event history; vector-similarity fallback when BM25
+returns zero results. `include_archived` (COGNIREPO-205) also searches events rotated
+out to `episodic_archive.json` by `episodic_max_events` rotation — default False (live
+store only). Archived hits are tagged `{"archived": true}`.
 
 **Input:**
 ```json
-{ "query": "redis cache bug", "limit": 5 }
+{ "query": "redis cache bug", "limit": 5, "include_archived": true }
 ```
 
 **Output:**
@@ -616,7 +619,8 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
     {"ts": "2026-08-08T09:00:00+00:00", "kind": "decision", "summary": "use FAISS for vector search", "ref": "e_42"},
     {"ts": "2026-08-07T14:00:00+00:00", "kind": "error", "summary": "ImportError (x3)", "ref": "ImportError"},
     {"ts": "2026-08-06T11:00:00+00:00", "kind": "session", "summary": "how does scoring work", "ref": "sess_abc123"}
-  ]
+  ],
+  "decision_nudge": "no decisions recorded yet — use record_decision for architectural choices"
 }
 ```
 
@@ -629,6 +633,17 @@ than a new MCP tool (0 manifest tokens vs. ~180 measured for a standalone
 plus the deterministic `rollup()` — counts + top decisions/errors, no model-generated
 text), call `data.memory.timeline.merge()`/`rollup()` directly, or from a future
 `generate_insights` tool (EPIC-300).
+
+**decision_nudge** (COGNIREPO-205): present only when the last 30 days have ≥5
+episodes but 0 decisions — a hint to use `record_decision` for architectural
+choices, since CLAUDE.md's instruction alone doesn't guarantee agents call it.
+Omitted from the payload entirely when there's nothing to nudge about.
+
+**Episodic events also include `index_event`-typed entries** (COGNIREPO-205):
+`cognirepo index-repo` and `cognirepo org rewire` completions are logged
+automatically (metadata `{"type": "index_event", ...}` with symbol/file or
+edge/repo counts), so infrastructure activity shows up in `recent_timeline` /
+`data.memory.timeline.merge()` even when no agent called `log_episode`.
 
 ---
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -202,15 +202,20 @@ freshness.
 **Output:**
 ```json
 {
-  "nodes": 1243,
-  "edges": 4871,
-  "node_types": { "FUNCTION": 892, "CLASS": 201, "FILE": 150 },
-  "healthy": true,
+  "node_count": 1243,
+  "edge_count": 4871,
+  "top_concepts": ["symbol::foo", "symbol::bar"],
   "last_indexed": "2026-07-22T18:20:10+00:00",
   "full_indexed_at": "2026-07-22T16:31:07+00:00",
   "index_age_minutes": 0,
   "index_stale": false,
-  "watcher_alive": true
+  "stale_reindexing_triggered": false,
+  "watcher_alive": true,
+  "integrity": {
+    "orphans": [],
+    "dangling_files": [],
+    "swept_at": "2026-07-31T12:00:00+00:00"
+  }
 }
 ```
 
@@ -227,6 +232,18 @@ freshness.
 Before COGNIREPO-D14, `last_indexed` only advanced on a full `index_repo()`
 run, so a repo kept current by the watcher reported a hours-old
 `last_indexed` next to `index_age_minutes: 0` — two clocks in one payload.
+
+**Integrity fields (COGNIREPO-201):**
+
+| Field | Meaning |
+|---|---|
+| `orphans` | FILE/FUNCTION/CLASS node IDs with degree 0 (no edges in or out). Excludes MEMORY/SESSION/ERROR/QUERY/CONCEPT nodes, which are legitimately edge-free early in their lifecycle. |
+| `dangling_files` | File paths (FILE node IDs, or FUNCTION/CLASS nodes' `file` attr) that no longer exist on disk — left behind when a file is deleted while no watcher/server was running to catch it. |
+| `swept_at` | ISO-8601 UTC timestamp of this integrity sweep — recomputed on every `graph_stats` call, O(nodes). |
+
+`doctor` flags nonzero `orphans`/`dangling_files` as a warning with a repair hint.
+`cognirepo graph repair [--apply]` prunes dangling file nodes (dry-run by default) —
+see [USAGE.md](USAGE.md).
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -172,13 +172,17 @@ cognirepo lookup-symbol Foo --include-org # also search sibling repos in the org
 cognirepo who-calls parse_config          # callers, from the call graph
 cognirepo subgraph interface/cli/main.py  # graph neighbourhood (--depth N)
 cognirepo graph-stats                     # node/edge counts + index freshness
+cognirepo graph repair                    # dry-run: list dangling file nodes
+cognirepo graph repair --apply            # prune them (orphan CONCEPTs untouched)
 cognirepo episodic-search "watcher crash" # keyword search over the event log
 ```
 
 `graph-stats` reports both clocks — `last_indexed` (any save, including the
 watcher's incremental path) and `full_indexed_at` (the last complete sweep) —
 plus `watcher_alive`, so "the index is fresh" and "something is keeping it
-fresh" are separate answers.
+fresh" are separate answers. It also gains an `integrity` block (orphans,
+dangling_files, swept_at) — `doctor` flags nonzero counts; `graph repair`
+prunes danglers (nodes whose file no longer exists on disk).
 
 ---
 

--- a/docs/architecture/graph.md
+++ b/docs/architecture/graph.md
@@ -19,6 +19,18 @@
 | `NodeType.USER_ACTION` | `"USER_ACTION"` | A recorded user interaction |
 | `NodeType.MEMORY` | `"MEMORY"` | Cross-agent memory node (synced from Claude/Gemini/etc.) |
 
+### Node attributes
+
+- `dispatch: "dynamic"` (COGNIREPO-203) — set on a FUNCTION/CLASS node when a static heuristic
+  detects it's reachable via dynamic dispatch rather than a visible call site: a celery-style
+  `@task`/`@shared_task` decorator, a `register(...)`-style plugin-registration call, a Python
+  `__init_subclass__` hook, or a packaging entry-point (`pyproject.toml`
+  `[project.entry-points.*]` / `setup.cfg` `[options.entry_points]`). Annotation-only — it never
+  fabricates a CALLS edge; it adds a `RELATES_TO` edge to the well-known CONCEPT node
+  `concept::dynamic_dispatch` so `subgraph()` surfaces it. `who_calls` returning few/no static
+  callers for such a symbol is expected, not a graph-integrity gap — check `dispatch` before
+  trusting an empty caller list.
+
 ---
 
 ## Edge Type Glossary

--- a/docs/architecture/graph.md
+++ b/docs/architecture/graph.md
@@ -35,6 +35,7 @@
 | `EdgeType.INHERITS` | `"INHERITS"` | CLASS → CLASS | Class A inherits from class B | `subgraph("BaseRetriever")` |
 | `EdgeType.EXPOSES` | `"EXPOSES"` | FUNCTION → ENDPOINT | A function handles a specific HTTP route/endpoint | `subgraph("api_handler")` |
 | `EdgeType.CALLS_ENDPOINT` | `"CALLS_ENDPOINT"` | FUNCTION → ENDPOINT | A function calls a remote endpoint stub (cross-service call) | `cross_repo_traverse("checkout", "payments")` |
+| `EdgeType.SIMILAR_TO` | `"SIMILAR_TO"` | FUNCTION/CLASS ↔ FUNCTION/CLASS | Embedding-distance near-duplicate symbols in different files (cosine ≥ 0.80, FAISS k-NN, max 5/node), added both directions | `subgraph("get_authorization_scheme_param")` |
 
 ### Direction notes
 
@@ -42,6 +43,9 @@
   This makes `who_calls(fn)` a simple outbound traversal from fn's node.
 - `DEFINED_IN` edges go from symbol → file, not file → symbol.
   This lets you find all symbols in a file via inbound traversal on the FILE node.
+- `SIMILAR_TO` is added in both directions (like `CALLS`/`CALLED_BY`) since similarity is
+  symmetric — `subgraph()`/`who_calls()` show the counterpart regardless of which side you
+  query from. Same-file pairs never get one — `DEFINED_IN` already relates those.
 
 ---
 

--- a/glama.json
+++ b/glama.json
@@ -151,6 +151,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/intelligence/indexer/ast_indexer.py
+++ b/intelligence/indexer/ast_indexer.py
@@ -143,6 +143,15 @@ _LITE_GRAPH_WEIGHT_MIN: float = 0.75
 _TIER1_WEIGHT_MIN: float = 0.5    # Tier 1: all BFS-reachable files (direct + indirect imports)
 _LARGE_REPO_TIER_THRESHOLD: int = _AUTO_SKIP_GRAPH_THRESHOLD  # same boundary as lite-graph
 
+# SIMILAR_TO edges: FAISS k-NN over already-embedded symbol vectors, post-index.
+# Cosine derived from the same "1 - l2_distance/2" convention hybrid.py/local_vector_db.py
+# use for unit-normalized fastembed vectors.
+_SIMILARITY_COSINE_THRESHOLD: float = 0.80
+_SIMILARITY_MAX_PER_NODE: int = 5
+# Above this many candidate symbols, similarity edges are off by default (O(n log n) k-NN
+# search cost) unless config.json explicitly opts in — see _similarity_gate_enabled().
+_SIMILARITY_SYMBOL_CEILING: int = 20_000
+
 
 
 def _effective_skip_dirs() -> frozenset[str]:
@@ -1514,8 +1523,13 @@ class ASTIndexer:
 
         self._build_reverse_index()
         # Resolve symbol:: stub nodes to real file-qualified nodes where unambiguous.
+        _similarity_edges = 0
         if not getattr(self, "_skip_graph", False):
             self._resolve_call_stubs()
+            try:
+                _similarity_edges = self._build_similarity_edges()
+            except Exception as _exc:  # pylint: disable=broad-except
+                log.warning("SIMILAR_TO edge pass failed (graph still valid): %s", _exc)
         total_symbols = sum(
             len(f.get("symbols", [])) for f in self.index_data["files"].values()
         )
@@ -1556,6 +1570,8 @@ class ASTIndexer:
                 f"Tier 2: {len(_tier2_pending)} low-weight files queued for background indexing. "
                 "Run: cognirepo index-repo . --tier 2"
             )
+        if _similarity_edges:
+            print(f"  SIMILAR_TO edges: {_similarity_edges}")
 
         # NOTE: doc ingestion deliberately does NOT run here. Every entry point
         # (cli/main.py index-repo Stage 3, cli/init_project.py, init-all) invokes
@@ -1570,6 +1586,7 @@ class ASTIndexer:
             "languages": dict(lang_file_counts),
             "skipped_extensions": sorted(skipped_exts),
             "tier2_queued": len(_tier2_pending),
+            "similarity_edges": _similarity_edges,
         }
 
     def index_file(self, rel_path: str, abs_path: str | None = None, weight: float = 1.0) -> dict:
@@ -1865,6 +1882,86 @@ class ASTIndexer:
 
             else:
                 self.graph.G.nodes[stub]["unresolved"] = True
+
+    def _similarity_gate_enabled(self, candidate_count: int) -> bool:
+        """config.json → {"indexing": {"similarity_edges": true|false}}.
+
+        Default: enabled below _SIMILARITY_SYMBOL_CEILING candidate symbols, off above
+        it (k-NN search cost scales with candidate count). Explicit config value wins
+        either way.
+        """
+        try:
+            with open(get_path("config.json"), encoding="utf-8") as f:
+                cfg = json.load(f)
+            gate = cfg.get("indexing", {}).get("similarity_edges")
+            if gate is not None:
+                return bool(gate)
+        except Exception:  # pylint: disable=broad-except
+            pass
+        return candidate_count < _SIMILARITY_SYMBOL_CEILING
+
+    def _build_similarity_edges(self) -> int:
+        """Post-index pass (COGNIREPO-202): FAISS k-NN over already-embedded FUNCTION/CLASS
+        symbol vectors, adding a SIMILAR_TO edge (both directions, like the CALLS/CALLED_BY
+        pair) between near-duplicate symbols in *different* files — same-file pairs are
+        already related via DEFINED_IN. Skipped entirely when the graph is empty (graph
+        indexing disabled) or the config gate is off.
+
+        Must run AFTER _batch_embed_pending() (faiss_index/faiss_meta populated) and
+        _resolve_call_stubs() (real symbol nodes exist, not just stubs).
+        """
+        if self.graph.G.number_of_nodes() == 0 or self.faiss_index is None or self.faiss_index.ntotal == 0:
+            return 0
+
+        candidates = [
+            (fid, m) for fid, m in enumerate(self.faiss_meta)
+            if m.get("source") == "symbol" and m.get("type") in (NodeType.FUNCTION, NodeType.CLASS)
+        ]
+        if len(candidates) < 2 or not self._similarity_gate_enabled(len(candidates)):
+            return 0
+
+        k = min(_SIMILARITY_MAX_PER_NODE + 1, self.faiss_index.ntotal)  # +1: self is always nearest
+        out_degree: dict[str, int] = {}
+        edges_added = 0
+
+        for fid, meta in candidates:
+            node_id = make_node_id(meta["type"], meta["name"], meta["file"])
+            if not self.graph.G.has_node(node_id) or out_degree.get(node_id, 0) >= _SIMILARITY_MAX_PER_NODE:
+                continue
+            try:
+                vec = self.faiss_index.reconstruct(int(fid)).reshape(1, -1)
+            except RuntimeError:
+                continue  # id was removed/never added — skip rather than crash the index pass
+            distances, ids = self.faiss_index.search(vec, k)
+
+            for dist, cand_fid in zip(distances[0], ids[0]):
+                if out_degree.get(node_id, 0) >= _SIMILARITY_MAX_PER_NODE:
+                    break
+                if cand_fid < 0 or cand_fid == fid or cand_fid >= len(self.faiss_meta):
+                    continue
+                cand_meta = self.faiss_meta[cand_fid]
+                if cand_meta.get("source") != "symbol" or cand_meta.get("type") not in (NodeType.FUNCTION, NodeType.CLASS):
+                    continue
+                if cand_meta["file"] == meta["file"]:
+                    continue  # DEFINED_IN already relates same-file symbols
+                cosine = max(0.0, 1.0 - float(dist) / 2.0)
+                if cosine < _SIMILARITY_COSINE_THRESHOLD:
+                    continue
+                cand_node_id = make_node_id(cand_meta["type"], cand_meta["name"], cand_meta["file"])
+                if cand_node_id == node_id or not self.graph.G.has_node(cand_node_id):
+                    continue
+                if out_degree.get(cand_node_id, 0) >= _SIMILARITY_MAX_PER_NODE:
+                    continue
+                if not self.graph.G.has_edge(node_id, cand_node_id):
+                    self.graph.add_edge(node_id, cand_node_id, EdgeType.SIMILAR_TO, weight=cosine)
+                    out_degree[node_id] = out_degree.get(node_id, 0) + 1
+                    edges_added += 1
+                if not self.graph.G.has_edge(cand_node_id, node_id):
+                    self.graph.add_edge(cand_node_id, node_id, EdgeType.SIMILAR_TO, weight=cosine)
+                    out_degree[cand_node_id] = out_degree.get(cand_node_id, 0) + 1
+                    edges_added += 1
+
+        return edges_added
 
     # ── kept for ASTIndexer API compatibility ─────────────────────────────────
 

--- a/intelligence/indexer/ast_indexer.py
+++ b/intelligence/indexer/ast_indexer.py
@@ -432,8 +432,15 @@ def _ts_docstring(node, source: bytes, ext: str) -> str:
 
 
 def _ts_collect_calls(node, source: bytes, out: list, depth: int = 0) -> None:
-    """Recursively collect function-call names from a tree-sitter subtree."""
-    if depth > 12:
+    """Recursively collect function-call names from a tree-sitter subtree.
+
+    COGNIREPO-203: the previous cap of 12 was too shallow for real code — a Go method
+    body wrapping an if-statement around `append(x, Struct{Field: recv.Method()})`
+    alone reaches depth 12-13 before the innermost call node is even visited, silently
+    dropping it. 60 comfortably covers realistic nesting while still bounding
+    pathological/generated input.
+    """
+    if depth > 60:
         return
     if node.type == "call":          # Python
         fn = node.child_by_field_name("function")
@@ -449,7 +456,10 @@ def _ts_collect_calls(node, source: bytes, out: list, depth: int = 0) -> None:
             or node.child_by_field_name("name")
         )
         if fn:
-            prop = fn.child_by_field_name("property")
+            prop = (
+                fn.child_by_field_name("property")  # JS/TS: obj.prop()
+                or fn.child_by_field_name("field")  # Go selector_expression: obj.Field()
+            )
             name_node = prop if prop else fn
             if name_node.type in ("identifier", "property_identifier", "field_identifier"):
                 method_name = _ts_text(name_node, source)
@@ -485,6 +495,24 @@ def _ts_decorators(parent_node, source: bytes) -> list[str]:
                     decs.append(_ts_text(sub, source).split("(")[0].strip())
                     break
     return decs
+
+
+# COGNIREPO-203: plugin-registry / dynamic-dispatch heuristics (README.md:626).
+# Annotation-only — these never fabricate CALLS edges, only flag a symbol as reachable
+# via a mechanism the static call graph can't see (framework registration, subclass
+# hooks), so who_calls callers can be cross-checked against dispatch:"dynamic" instead
+# of trusting an empty/short static caller list at face value.
+_DYNAMIC_DISPATCH_DECORATOR_TAILS = frozenset({"task", "shared_task"})  # celery-style
+
+
+def _detect_dynamic_dispatch(name: str, decorators: list[str], calls: list[str]) -> bool:
+    if name == "__init_subclass__":
+        return True
+    for dec in decorators:
+        tail = dec.rsplit(".", 1)[-1]
+        if tail in _DYNAMIC_DISPATCH_DECORATOR_TAILS:
+            return True
+    return "register" in calls
 
 
 def _ts_bases(node, source: bytes) -> list[str]:
@@ -528,30 +556,37 @@ def _walk_ts(node, source: bytes, ext: str, out: list, _parent_decs: "list[str] 
         if name_node:
             calls: list[str] = []
             _ts_collect_calls(node, source, calls)
+            fn_name = _ts_text(name_node, source)
+            fn_decs = _parent_decs or []
+            fn_calls = list(dict.fromkeys(calls))
             out.append({
-                "name": _ts_text(name_node, source),
+                "name": fn_name,
                 "type": "FUNCTION",
                 "start_line": node.start_point[0] + 1,
                 "end_line": node.end_point[0] + 1,
                 "docstring": _ts_docstring(node, source, ext),
-                "decorators": _parent_decs or [],
+                "decorators": fn_decs,
                 "tags": [],
-                "calls": list(dict.fromkeys(calls)),
+                "calls": fn_calls,
                 "bases": [],
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(fn_name, fn_decs, fn_calls) else None,
             })
     elif node.type in _TS_CLASS_TYPES:
         name_node = node.child_by_field_name("name")
         if name_node:
+            cls_name = _ts_text(name_node, source)
+            cls_decs = _parent_decs or []
             out.append({
-                "name": _ts_text(name_node, source),
+                "name": cls_name,
                 "type": "CLASS",
                 "start_line": node.start_point[0] + 1,
                 "end_line": node.end_point[0] + 1,
                 "docstring": _ts_docstring(node, source, ext),
-                "decorators": _parent_decs or [],
+                "decorators": cls_decs,
                 "tags": [],
                 "calls": [],
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(cls_name, cls_decs, []) else None,
                 "bases": _ts_bases(node, source),
                 "faiss_id": -1,
             })
@@ -654,6 +689,83 @@ def _resolve_import_to_file(
             if tracked_files is None or candidate in tracked_files:
                 return candidate
     return None
+
+
+# ── import extraction (Go) ─────────────────────────────────────────────────────
+
+_GO_MODULE_CACHE: "dict[str, str | None]" = {}
+
+
+def _go_module_name(repo_root: str) -> "str | None":
+    """Read the `module <path>` line from go.mod at the repo root (cached per root)."""
+    if repo_root in _GO_MODULE_CACHE:
+        return _GO_MODULE_CACHE[repo_root]
+    mod_name = None
+    try:
+        with open(os.path.join(repo_root, "go.mod"), encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("module "):
+                    mod_name = line[len("module "):].strip()
+                    break
+    except OSError:
+        pass
+    _GO_MODULE_CACHE[repo_root] = mod_name
+    return mod_name
+
+
+def _extract_imports_go(tree, source: bytes) -> list[dict]:
+    """Extract import_spec paths from a Go tree-sitter tree.
+
+    Returns list of dicts: {module, alias, line}. module is the raw import path
+    (e.g. "github.com/foo/bar/pkg/util"); alias is the local package name/alias.
+    """
+    imports: list[dict] = []
+
+    def _walk(node) -> None:
+        if node.type == "import_spec":
+            path_node = node.child_by_field_name("path")
+            if path_node:
+                raw = _ts_text(path_node, source).strip('"')
+                name_node = node.child_by_field_name("name")
+                alias = _ts_text(name_node, source) if name_node else raw.rsplit("/", 1)[-1]
+                imports.append({"module": raw, "alias": alias, "line": node.start_point[0] + 1})
+            return  # import_spec has no nested import_specs
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree.root_node)
+    return imports
+
+
+def _resolve_go_import_to_file(module: str, repo_root: str) -> "str | None":
+    """Resolve a Go import path to a representative local .go file.
+
+    Go packages are directories, not files — CogniRepo's IMPORTS edges are FILE→FILE,
+    so this picks the first non-test .go file (sorted) in the resolved package
+    directory as a stand-in for "this file imports that package". Only resolves
+    imports that belong to this repo's own module (per go.mod); stdlib/third-party
+    imports return None (nothing to link to locally), matching the Python resolver's
+    best-effort, local-only behaviour.
+    """
+    mod_name = _go_module_name(repo_root)
+    if not mod_name or not (module == mod_name or module.startswith(mod_name + "/")):
+        return None
+    rel_dir = module[len(mod_name):].lstrip("/")
+    abs_dir = os.path.join(repo_root, rel_dir) if rel_dir else repo_root
+    if not os.path.isdir(abs_dir):
+        return None
+    try:
+        go_files = sorted(
+            f for f in os.listdir(abs_dir)
+            if f.endswith(".go") and not f.endswith("_test.go")
+        )
+    except OSError:
+        return None
+    if not go_files:
+        return None
+    candidate = os.path.join(rel_dir, go_files[0]) if rel_dir else go_files[0]
+    return candidate.replace(os.sep, "/")
 
 
 # ── stdlib-ast extraction (Python fallback) ───────────────────────────────────
@@ -780,6 +892,7 @@ def _extract_symbols_py(tree: ast.AST, _file_path: str) -> list[dict]:
                 "tags": tags,
                 "dynamic_registers": dyn_targets,
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(node.name, decorators, calls) else None,
             })
 
         elif isinstance(node, ast.ClassDef):
@@ -804,6 +917,7 @@ def _extract_symbols_py(tree: ast.AST, _file_path: str) -> list[dict]:
                 "dynamic_registers": [],
                 "bases": bases,
                 "faiss_id": -1,
+                "dispatch": "dynamic" if _detect_dynamic_dispatch(node.name, _extract_decorators(node), []) else None,
             })
 
     # ── 2. module / class-level assignments → CONSTANT / VARIABLE ────────────
@@ -1524,12 +1638,17 @@ class ASTIndexer:
         self._build_reverse_index()
         # Resolve symbol:: stub nodes to real file-qualified nodes where unambiguous.
         _similarity_edges = 0
+        _entry_point_dispatch = 0
         if not getattr(self, "_skip_graph", False):
             self._resolve_call_stubs()
             try:
                 _similarity_edges = self._build_similarity_edges()
             except Exception as _exc:  # pylint: disable=broad-except
                 log.warning("SIMILAR_TO edge pass failed (graph still valid): %s", _exc)
+            try:
+                _entry_point_dispatch = self._apply_entry_points_dispatch()
+            except Exception as _exc:  # pylint: disable=broad-except
+                log.warning("entry_points dispatch pass failed (graph still valid): %s", _exc)
         total_symbols = sum(
             len(f.get("symbols", [])) for f in self.index_data["files"].values()
         )
@@ -1572,6 +1691,8 @@ class ASTIndexer:
             )
         if _similarity_edges:
             print(f"  SIMILAR_TO edges: {_similarity_edges}")
+        if _entry_point_dispatch:
+            print(f"  dispatch:dynamic (entry_points): {_entry_point_dispatch}")
 
         # NOTE: doc ingestion deliberately does NOT run here. Every entry point
         # (cli/main.py index-repo Stage 3, cli/init_project.py, init-all) invokes
@@ -1587,6 +1708,7 @@ class ASTIndexer:
             "skipped_extensions": sorted(skipped_exts),
             "tier2_queued": len(_tier2_pending),
             "similarity_edges": _similarity_edges,
+            "entry_point_dispatch": _entry_point_dispatch,
         }
 
     def index_file(self, rel_path: str, abs_path: str | None = None, weight: float = 1.0) -> dict:
@@ -1696,8 +1818,15 @@ class ASTIndexer:
                 file_node = make_node_id("FILE", rel_path)
                 sym_node = node_id_from_symbol_record(sym, rel_path)
                 self.graph.add_node(file_node, NodeType.FILE, weight=weight)
-                self.graph.add_node(sym_node, sym["type"], file=rel_path, line=sym["start_line"], weight=weight)
+                node_attrs = {"file": rel_path, "line": sym["start_line"], "weight": weight}
+                if sym.get("dispatch") == "dynamic":
+                    node_attrs["dispatch"] = "dynamic"
+                self.graph.add_node(sym_node, sym["type"], **node_attrs)
                 self.graph.add_edge(sym_node, file_node, EdgeType.DEFINED_IN)
+                if sym.get("dispatch") == "dynamic":
+                    dispatch_node = make_node_id("CONCEPT", "dynamic_dispatch")
+                    self.graph.add_node(dispatch_node, NodeType.CONCEPT)
+                    self.graph.add_edge(sym_node, dispatch_node, EdgeType.RELATES_TO)
 
         # ── file-level summary embedding ──────────────────────────────────────
         if embed_enabled and raw_symbols:
@@ -1776,6 +1905,24 @@ class ASTIndexer:
                         self.graph.add_node(target_node, NodeType.FILE)
                         self.graph.add_edge(file_node, target_node, EdgeType.IMPORTS)
             except (SyntaxError, OSError):
+                pass  # best-effort
+        elif ext == ".go":
+            try:
+                _go_lang = _get_language(ext)
+                if _go_lang is not None:
+                    from tree_sitter import Parser as _Parser  # pylint: disable=import-outside-toplevel
+                    _go_source = Path(abs_path).read_bytes()
+                    _go_tree = _Parser(_go_lang).parse(_go_source)
+                    _imports = _extract_imports_go(_go_tree, _go_source)
+                    _repo_root = self.index_data.get("repo_root") or os.getcwd()
+                    file_node = make_node_id("FILE", rel_path)
+                    for imp in _imports:
+                        _target = _resolve_go_import_to_file(imp["module"], _repo_root)
+                        if _target and _target != rel_path:
+                            target_node = make_node_id("FILE", _target)
+                            self.graph.add_node(target_node, NodeType.FILE)
+                            self.graph.add_edge(file_node, target_node, EdgeType.IMPORTS)
+            except OSError:
                 pass  # best-effort
 
         file_record = {
@@ -1962,6 +2109,67 @@ class ASTIndexer:
                     edges_added += 1
 
         return edges_added
+
+    def _apply_entry_points_dispatch(self) -> int:
+        """Post-index pass (COGNIREPO-203): tag symbols referenced by a packaging
+        entry-point (PEP 621 `[project.entry-points.*]` in pyproject.toml, or
+        `[options.entry_points]` in setup.cfg) as dispatch:"dynamic" — these are
+        invoked by name lookup at runtime (plugin loaders, console_scripts) rather
+        than a visible call site, so the static call graph can never find their
+        caller. Best-effort name match only (target's last dotted component vs.
+        symbol name) — does not verify the module path, matching the same
+        local-only, best-effort spirit as `_resolve_import_to_file`.
+        """
+        repo_root = self.index_data.get("repo_root") or os.getcwd()
+        targets: "set[str]" = set()
+
+        pyproject = os.path.join(repo_root, "pyproject.toml")
+        if os.path.isfile(pyproject):
+            try:
+                import tomllib  # pylint: disable=import-outside-toplevel
+                with open(pyproject, "rb") as f:
+                    data = tomllib.load(f)
+                for group in data.get("project", {}).get("entry-points", {}).values():
+                    for value in group.values():
+                        if ":" in value:
+                            targets.add(value.split(":")[-1].split(".")[-1].strip())
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        setup_cfg = os.path.join(repo_root, "setup.cfg")
+        if os.path.isfile(setup_cfg):
+            try:
+                import configparser  # pylint: disable=import-outside-toplevel
+                cp = configparser.ConfigParser()
+                cp.read(setup_cfg)
+                for section in cp.sections():
+                    if section == "options.entry_points" or section.startswith("options.entry_points."):
+                        for _key, value in cp.items(section):
+                            for line in value.splitlines():
+                                line = line.strip()
+                                if "=" in line:
+                                    _, target = line.split("=", 1)
+                                    target = target.strip()
+                                    if ":" in target:
+                                        targets.add(target.split(":")[-1].split(".")[-1].strip())
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+        if not targets:
+            return 0
+
+        tagged = 0
+        dispatch_node = make_node_id("CONCEPT", "dynamic_dispatch")
+        for node_id, data in list(self.graph.G.nodes(data=True)):
+            if data.get("type") not in (NodeType.FUNCTION, NodeType.CLASS):
+                continue
+            name = node_id.rsplit("::", 1)[-1]
+            if name in targets and data.get("dispatch") != "dynamic":
+                self.graph.G.nodes[node_id]["dispatch"] = "dynamic"
+                self.graph.add_node(dispatch_node, NodeType.CONCEPT)
+                self.graph.add_edge(node_id, dispatch_node, EdgeType.RELATES_TO)
+                tagged += 1
+        return tagged
 
     # ── kept for ASTIndexer API compatibility ─────────────────────────────────
 

--- a/intelligence/retrieval/hybrid.py
+++ b/intelligence/retrieval/hybrid.py
@@ -33,7 +33,7 @@ import numpy as np
 from core._bm25 import BM25 as _BM25, Document as _Document
 from data.graph.behaviour_tracker import BehaviourTracker
 from data.graph.graph_utils import extract_entities_from_text, make_node_id
-from data.graph.knowledge_graph import KnowledgeGraph
+from data.graph.knowledge_graph import KnowledgeGraph, EdgeType
 from intelligence.indexer.ast_indexer import ASTIndexer
 from data.memory.circuit_breaker import CircuitOpenError
 from data.memory.embeddings import encode_with_timeout
@@ -45,6 +45,11 @@ from core.config.paths import get_path
 def _config_file() -> str:
     return get_path("config.json")
 DEFAULT_WEIGHTS = {"vector": 0.5, "graph": 0.3, "behaviour": 0.2}
+
+# A 1-hop link that is SIMILAR_TO-only (no CALLS/DEFINED_IN/IMPORTS/etc. also connecting the
+# pair) is weaker relevance evidence than a real structural edge — discount it below the
+# vanilla 1-hop score (0.5) but keep it above 2-hop (0.333). COGNIREPO-202.
+_SIMILAR_TO_ONLY_DISCOUNT = 0.7
 
 
 def _load_weights() -> dict[str, float]:
@@ -366,6 +371,7 @@ class HybridRetriever:  # pylint: disable=too-few-public-methods
         g_undirected = self._undirected
 
         min_hops = None
+        best_entity_node = None
         for entity in query_entities:
             # Collect all candidate node IDs for this entity:
             # 1. Generic forms (concept/file/symbol prefixes)
@@ -395,6 +401,7 @@ class HybridRetriever:  # pylint: disable=too-few-public-methods
                         hops = 1_000_000
                 if min_hops is None or hops < min_hops:
                     min_hops = hops
+                    best_entity_node = node_id
                     if min_hops == 0:
                         break  # exact match — no need to keep searching
             if min_hops == 0:
@@ -402,7 +409,17 @@ class HybridRetriever:  # pylint: disable=too-few-public-methods
 
         if min_hops is None or min_hops >= 1_000_000:
             return 0.0
-        return 1.0 / (1.0 + min_hops)
+        score = 1.0 / (1.0 + min_hops)
+        if min_hops == 1 and best_entity_node and self._is_similar_to_only_link(best_entity_node, cand_node):
+            score *= _SIMILAR_TO_ONLY_DISCOUNT
+        return score
+
+    def _is_similar_to_only_link(self, a: str, b: str) -> bool:
+        """True if the only edge(s) directly connecting a and b are SIMILAR_TO."""
+        edge_ab = self.graph.G.get_edge_data(a, b)
+        edge_ba = self.graph.G.get_edge_data(b, a)
+        rels = [e.get("rel") for e in (edge_ab, edge_ba) if e]
+        return bool(rels) and all(r == EdgeType.SIMILAR_TO for r in rels)
 
     @staticmethod
     def _behaviour_score(

--- a/interface/adapters/openai_tools.json
+++ b/interface/adapters/openai_tools.json
@@ -161,6 +161,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -2207,6 +2207,20 @@ def _direct_index(path, embed: bool = True, skip_graph: bool | None = None, tier
     except Exception:  # pylint: disable=broad-except
         pass  # non-fatal
 
+    try:
+        from data.memory.episodic_memory import log_event as _log_index_event  # pylint: disable=import-outside-toplevel
+        _log_index_event(
+            f"index-repo completed: {n_symbols:,} symbols across {n_files:,} files",
+            metadata={
+                "type": "index_event",
+                "symbols": n_symbols,
+                "files": n_files,
+                "elapsed_s": round(elapsed, 2),
+            },
+        )
+    except Exception:  # pylint: disable=broad-except
+        pass  # non-fatal — indexing already succeeded
+
     _write_last_indexed_sha(abs_path)
 
     # Auto-launch Tier 2 background if pending queue exists (files or embed deferred).
@@ -4216,6 +4230,14 @@ def _main():
                 finally:
                     _CTX_DIR.reset(token)
             print(f"Rewire complete — {total} CALLS_API edge(s) across {len(indexed)} indexed repo(s).")
+            try:
+                from data.memory.episodic_memory import log_event as _log_rewire_event  # pylint: disable=import-outside-toplevel
+                _log_rewire_event(
+                    f"org rewire completed: {total} edges across {len(indexed)} repos",
+                    metadata={"type": "index_event", "edges": total, "repos": len(indexed)},
+                )
+            except Exception:  # pylint: disable=broad-except
+                pass  # non-fatal — rewire already succeeded
         elif args.org_command == "graph":
             from data.graph.org_graph import get_org_graph  # pylint: disable=import-outside-toplevel
             og = get_org_graph()

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -276,6 +276,45 @@ def _cmd_verify_index(verbose: bool = False) -> int:
     return 1 if issues else 0
 
 
+def _cmd_graph_repair(apply: bool = False) -> int:
+    """
+    Prune dangling file nodes (and their symbols) from the knowledge graph.
+
+    Dry-run by default — reports what integrity_report() found without
+    mutating the graph. --apply removes them via remove_file_nodes(), which
+    redirects any live call/inherit edges onto an unresolved CONCEPT stub
+    rather than dropping them, and leaves orphan CONCEPT stubs untouched
+    (they carry no 'file' attr, so nodes_for_file() never matches them).
+    See COGNIREPO-201.
+    """
+    # pylint: disable=import-outside-toplevel
+    from data.graph.knowledge_graph import KnowledgeGraph
+
+    kg = KnowledgeGraph()
+    repo_root = os.path.dirname(os.path.abspath(get_path("")))
+    report = kg.integrity_report(repo_root)
+    dangling = report["dangling_files"]
+
+    if not dangling:
+        print("graph repair: no dangling file nodes found.")
+        return 0
+
+    print(f"graph repair: {len(dangling)} dangling file path(s) found:")
+    for f in dangling:
+        print(f"  {f}")
+
+    if not apply:
+        print("\nDry run — no changes made. Re-run with --apply to prune.")
+        return 0
+
+    removed_total = 0
+    for f in dangling:
+        removed_total += len(kg.remove_file_nodes(f))
+    kg.save()
+    print(f"\nRemoved {removed_total} node(s) across {len(dangling)} dangling file path(s).")
+    return 0
+
+
 def _check_working_tree_dirty(manifest: dict) -> list[str]:
     """
     Return the list of indexed source paths with uncommitted working-tree changes.
@@ -517,6 +556,20 @@ def _cmd_doctor(verbose: bool = False, release_check: bool = False, as_json: boo
         if verbose:
             _gpath = get_path("graph/graph.pkl")
             print(f"       {os.path.abspath(_gpath)}")
+
+        # ── Check 3a: Knowledge graph integrity (COGNIREPO-201) ────────────────
+        _repo_root = os.path.dirname(os.path.abspath(get_path("")))
+        _integrity = _kg.integrity_report(_repo_root)
+        _n_orphans = len(_integrity["orphans"])
+        _n_dangling = len(_integrity["dangling_files"])
+        if _n_orphans == 0 and _n_dangling == 0:
+            _ok("Graph integrity — 0 orphans · 0 dangling files")
+        else:
+            _warn(
+                f"Graph integrity — {_n_orphans} orphan node(s), "
+                f"{_n_dangling} dangling file(s)",
+                "Run: cognirepo graph repair --apply",
+            )
     except Exception as exc:  # pylint: disable=broad-except
         _fail(f"Knowledge graph — {exc}", "Run: cognirepo index-repo .")
         issues += 1
@@ -2597,6 +2650,7 @@ def _print_help() -> None:
     _row("who-calls <fn>",    "Trace callers of a function in the call graph")
     _row("subgraph <entity>", "Show knowledge-graph neighbourhood for an entity")
     _row("graph-stats",       "Node/edge count and health of the knowledge graph")
+    _row("graph repair",      "Prune dangling file nodes from the graph (--apply to write)")
 
     # ── AI Query ──────────────────────────────────────────────────────────────
     _hdr("AI QUERY")
@@ -3188,6 +3242,18 @@ def _main():
     p_sub.add_argument("--depth", type=int, default=2)
 
     sub.add_parser("graph-stats", help="Node/edge count and health of the knowledge graph")
+
+    # graph (COGNIREPO-201) — integrity maintenance, separate from graph-stats above
+    p_graph = sub.add_parser("graph", help="Knowledge-graph integrity maintenance")
+    graph_sub = p_graph.add_subparsers(dest="graph_command")
+    p_graph_repair = graph_sub.add_parser(
+        "repair",
+        help="Prune dangling file nodes from the knowledge graph (dry-run by default)",
+    )
+    p_graph_repair.add_argument(
+        "--apply", action="store_true",
+        help="Actually prune (default: dry-run report only)",
+    )
 
     p_mcpset = sub.add_parser("mcp-setup", help="Re-run MCP integration (Claude / Gemini / Cursor)")
     p_mcpset.add_argument("--target", action="append", dest="targets",
@@ -4391,6 +4457,12 @@ def _main():
                 _print_results(_srv.subgraph(args.entity, depth=args.depth))
             else:  # graph-stats
                 _print_results(_srv.graph_stats())
+
+        elif args.command == "graph":
+            if getattr(args, "graph_command", None) == "repair":
+                sys.exit(_cmd_graph_repair(apply=getattr(args, "apply", False)))
+            print("Usage: cognirepo graph repair [--apply]")
+            sys.exit(2)
 
         elif args.command == "mcp-setup":
             from interface.cli.init_project import setup_mcp  # pylint: disable=import-outside-toplevel

--- a/interface/server/manifest.json
+++ b/interface/server/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "cognirepo",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "transport": "stdio",
   "tools": [
     {

--- a/interface/server/manifest.json
+++ b/interface/server/manifest.json
@@ -148,6 +148,10 @@
             "default": 10,
             "type": "integer"
           },
+          "include_archived": {
+            "default": false,
+            "type": "boolean"
+          },
           "repo_path": {
             "default": null,
             "type": "string"

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1519,14 +1519,22 @@ def subgraph(entity: str, depth: int = 2, repo_path: str | None = None) -> dict:
 
 
 @mcp.tool()
-def episodic_search(query: str, limit: int = 10, repo_path: str | None = None) -> list:
+def episodic_search(
+    query: str,
+    limit: int = 10,
+    include_archived: bool = False,
+    repo_path: str | None = None,
+) -> list:
     """
     Return past episodic events matching a keyword query.
 
+    include_archived: also search events rotated out of the live store
+    (episodic_archive.json). Default False — live store only. Archived hits
+    are tagged {"archived": True}.
     repo_path: optional absolute path to the target repository.
     """
     with _repo_ctx(repo_path):
-        result = search_episodes(query, limit)
+        result = search_episodes(query, limit, include_archived)
     _behaviour_record_query(query, result)
     try:
         from interface.tools.context_pack import save_query_context  # pylint: disable=import-outside-toplevel
@@ -1939,6 +1947,19 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         except Exception:  # pylint: disable=broad-except
             pass
 
+        # ── decision-coverage nudge (COGNIREPO-205) ─────────────────────────────
+        # Agents that never call record_decision leave the timeline's decision
+        # count at 0 even as episodes pile up — nudge once that gap is clear,
+        # rather than relying on CLAUDE.md instructions alone.
+        decision_nudge = ""
+        try:
+            from data.memory.timeline import merge as _nudge_merge, rollup as _nudge_rollup  # pylint: disable=import-outside-toplevel
+            _counts = _nudge_rollup(_nudge_merge(since="30d", limit=200))["counts"]
+            if _counts.get("decision", 0) == 0 and _counts.get("episode", 0) >= 5:
+                decision_nudge = "no decisions recorded yet — use record_decision for architectural choices"
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     # ── child services (orchestrator repos only) ──────────────────────────────
     child_services: list[dict] = []
     try:
@@ -1977,6 +1998,8 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
     }
     if child_services:
         result["child_services"] = child_services
+    if decision_nudge:
+        result["decision_nudge"] = decision_nudge
     return result
 
 

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1800,41 +1800,13 @@ def get_session_history(limit: int = 10, repo_path: str | None = None) -> list:
     repo_path: optional absolute path to the target repository.
     """
     with _repo_ctx(repo_path):
-        from core.config.paths import get_path as _gp  # pylint: disable=import-outside-toplevel
-        import glob  # pylint: disable=import-outside-toplevel
-        sessions_dir = _gp("sessions")
-        if not os.path.isdir(sessions_dir):
-            return []
-        session_files = sorted(
-            glob.glob(os.path.join(sessions_dir, "*.json")),
-            key=os.path.getmtime,
-            reverse=True,
-        )
-        # exclude the "current.json" pointer file
-        session_files = [f for f in session_files if not f.endswith("current.json")]
+        from data.memory.timeline import _list_session_files, parse_session_file  # pylint: disable=import-outside-toplevel
+        session_files = sorted(_list_session_files(), key=os.path.getmtime, reverse=True)
         results = []
         for sf in session_files[:limit]:
-            try:
-                with open(sf, encoding="utf-8") as f:
-                    data = json.load(f)
-                messages = data.get("messages", [])
-                # get last user/assistant exchange
-                last_exchange = {}
-                for i in range(len(messages) - 1, -1, -1):
-                    if messages[i].get("role") == "assistant":
-                        last_exchange["assistant"] = messages[i].get("content", "")[:300]
-                    elif messages[i].get("role") == "user" and "assistant" in last_exchange:
-                        last_exchange["user"] = messages[i].get("content", "")[:300]
-                        break
-                results.append({
-                    "session_id": data.get("session_id", os.path.basename(sf)),
-                    "created_at": data.get("created_at"),
-                    "message_count": len(messages),
-                    "model": data.get("model", "unknown"),
-                    "last_exchange": last_exchange,
-                })
-            except (OSError, json.JSONDecodeError):
-                continue
+            parsed = parse_session_file(sf)
+            if parsed is not None:
+                results.append(parsed)
     return results
 
 
@@ -1853,6 +1825,10 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
       framing       — {depth, vocabulary} from user profile (empty if tracking off)
       error_patterns — top 3 recurring errors with prevention hints
       index_health  — {symbols, files, status}
+      recent_timeline — last 5 entries (past 7 days) merged across sessions,
+                        episodes, decisions, and errors — {ts, kind, summary, ref}
+                        each; see data/memory/timeline.py::merge() for the full
+                        query surface (since/include_archived/limit)
 
     Claude: call this ONCE at session start instead of the 4 individual calls.
     Use individual tools only when you need the full detail each provides.
@@ -1951,6 +1927,18 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         except Exception:  # pylint: disable=broad-except
             pass
 
+        # ── recent timeline digest (COGNIREPO-204) ──────────────────────────────
+        # 5-entry digest folded into bootstrap's existing output rather than a new
+        # MCP tool — 0 manifest tokens vs. ~140 for a standalone get_timeline
+        # (measured on the PR), replacing what would otherwise be a 3-call stitch
+        # (get_session_history + episodic_search + get_error_patterns).
+        recent_timeline: list = []
+        try:
+            from data.memory.timeline import merge as _timeline_merge  # pylint: disable=import-outside-toplevel
+            recent_timeline = _timeline_merge(since="7d", limit=5)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     # ── child services (orchestrator repos only) ──────────────────────────────
     child_services: list[dict] = []
     try:
@@ -1985,6 +1973,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         "framing": framing,
         "error_patterns": error_patterns,
         "index_health": {"symbols": symbol_count, "files": file_count, "status": index_status},
+        "recent_timeline": recent_timeline,
     }
     if child_services:
         result["child_services"] = child_services

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1565,6 +1565,9 @@ def graph_stats(repo_path: str | None = None) -> dict:
         if g is None:
             g = _get_graph()
         stats = g.stats()
+        from core.config.paths import get_cognirepo_dir  # pylint: disable=import-outside-toplevel
+        integrity_root = _root or os.path.dirname(os.path.abspath(get_cognirepo_dir()))
+        integrity = g.integrity_report(integrity_root)
         from data.graph.knowledge_graph import PYTHON_BUILTINS  # pylint: disable=import-outside-toplevel
         concept_nodes = [
             n for n, d in g.G.nodes(data=True)
@@ -1626,6 +1629,7 @@ def graph_stats(repo_path: str | None = None) -> dict:
         "index_stale": index_stale,
         "stale_reindexing_triggered": stale_reindexing_triggered,
         "watcher_alive": watcher_alive,
+        "integrity": integrity,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ cpp = [
     "scikit-build-core>=0.9",
 ]
 security = [
-    "cryptography>=48.0.1",
+    "cryptography>=50.0.0",
     "keyring>=25.0",
 ]
 cli = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognirepo"
-version = "2.0.1"
+version = "2.1.0"
 description = "Local cognitive infrastructure layer for AI agents"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ charset-normalizer==3.4.6
 chromadb==1.5.9
 click==8.3.3
 coverage==7.13.5
-cryptography==48.0.1
+cryptography==50.0.0
 distro==1.9.0
 docstring_parser==0.17.0
 durationpy==0.10

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/ashlesh-t/cognirepo",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirepo",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -82,6 +82,8 @@ def _run_doctor(
                 return 4218
         class _FakeKG:
             G = _FakeG()
+            def integrity_report(self, repo_root):  # pylint: disable=unused-argument
+                return {"orphans": [], "dangling_files": [], "swept_at": "2026-01-01T00:00:00+00:00"}
         fake_graph_mod.KnowledgeGraph = _FakeKG
     monkeypatch.setitem(sys.modules, "data.graph.knowledge_graph", fake_graph_mod)
 
@@ -334,6 +336,37 @@ class TestDoctorGraphQuarantine:
 
         assert "corrupt-" not in out
         assert code == 0
+
+
+class TestDoctorGraphIntegrity:
+    """COGNIREPO-201 AC2: doctor flags a seeded dangling node; clean fresh index reports 0/0."""
+
+    def test_dangling_node_produces_warn(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_doctor
+
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+        kg.save()
+
+        code = _cmd_doctor(verbose=False)
+        out = capsys.readouterr().out
+        assert "Graph integrity" in out
+        assert "1 dangling file" in out
+        assert "cognirepo graph repair --apply" in out
+        assert code >= 1
+
+    def test_clean_graph_reports_zero(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph
+        from interface.cli.main import _cmd_doctor
+
+        KnowledgeGraph().save()
+
+        _cmd_doctor(verbose=False)
+        out = capsys.readouterr().out
+        assert "Graph integrity — 0 orphans · 0 dangling files" in out
 
 
 class TestDoctorWorkingTreeDirty:

--- a/tests/test_episodic_205.py
+++ b/tests/test_episodic_205.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_episodic_205.py — COGNIREPO-205 acceptance criteria.
+
+1. search_episodes(include_archived=...) — archived events are searchable only
+   with the flag; default behavior (live-only) is unchanged.
+2. Persistent embedding cache for the semantic fallback — repeat searches over
+   an unchanged corpus re-encode 0 documents (only the query, if anything).
+3. index-repo logs exactly one index_event episode on a fixture repo.
+4. datetime.utcnow() deprecation removed from episodic_memory.py.
+"""
+from __future__ import annotations
+
+import json
+
+
+# ── AC1: archive search ─────────────────────────────────────────────────────
+
+class TestArchiveSearch:
+    def test_archived_hit_found_only_with_flag(self, tmp_path, monkeypatch):
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        # live store: nothing matching
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        live = [{"id": "e_1", "event": "reviewed PR", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps(live))
+
+        # archive: unique keyword
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+
+        without_flag = search_episodes("zanzibar", limit=5, include_archived=False)
+        assert without_flag == []
+
+        with_flag = search_episodes("zanzibar", limit=5, include_archived=True)
+        by_id = {r["id"]: r for r in with_flag}
+        assert "e_0" in by_id, "archived entry must be findable with include_archived=True"
+        assert by_id["e_0"]["archived"] is True
+
+    def test_live_hit_not_marked_archived(self, tmp_path, monkeypatch):
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        live = [{"id": "e_1", "event": "zanzibar deployed to prod", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps(live))
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+        results = search_episodes("zanzibar", limit=5, include_archived=True)
+        ids = {r["id"] for r in results}
+        assert ids == {"e_0", "e_1"}
+        live_result = next(r for r in results if r["id"] == "e_1")
+        assert "archived" not in live_result
+
+    def test_default_excludes_archive(self, tmp_path, monkeypatch):
+        """include_archived defaults to False — matches TC-205-1's expectation."""
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+
+        (tmp_path / ".cognirepo" / "memory").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".cognirepo" / "memory" / "episodic.json").write_text(json.dumps([]))
+        archived = [{"id": "e_0", "event": "zanzibar migration notes", "metadata": {}, "time": "2026-07-01T00:00:00Z"}]
+        (tmp_path / ".cognirepo" / "memory" / "episodic_archive.json").write_text(json.dumps(archived))
+
+        from data.memory.episodic_memory import search_episodes
+        assert search_episodes("zanzibar", limit=5) == []
+
+
+# ── AC2: persistent embedding cache ──────────────────────────────────────────
+
+class TestSemanticSearchEmbeddingCache:
+    def test_second_identical_search_reencodes_no_entries(self, tmp_path, monkeypatch):
+        import numpy as np
+        import data.memory.episodic_memory as em
+
+        entries = [
+            {"id": f"e_{i}", "event": f"unique topic phrase number {i}", "metadata": {}, "time": "2026-08-01T00:00:00Z"}
+            for i in range(5)
+        ]
+
+        calls = {"n": 0}
+        rng = np.random.default_rng(42)
+        vec_by_text: dict[str, "np.ndarray"] = {}
+
+        def _fake_encode(text, timeout=None):
+            calls["n"] += 1
+            if text not in vec_by_text:
+                vec_by_text[text] = rng.random(8).astype("float32")
+            return vec_by_text[text]
+
+        monkeypatch.setattr("data.memory.embeddings.encode_with_timeout", _fake_encode)
+
+        # BM25 returns nothing for this query -> forces the semantic fallback
+        query = "zzz_no_bm25_overlap_zzz"
+
+        first = em._semantic_episode_search(entries, query, limit=5)
+        calls_after_first = calls["n"]
+        assert calls_after_first == len(entries) + 1  # 5 entries + 1 query
+
+        calls["n"] = 0
+        second = em._semantic_episode_search(entries, query, limit=5)
+        # Only the query needs encoding again — all 5 entries now cache hits.
+        assert calls["n"] == 1
+
+    def test_embedding_cache_written_to_disk_and_reloadable(self, tmp_path, monkeypatch):
+        """Cache file + id sidecar are written under .cognirepo/memory/ and reloadable."""
+        import numpy as np
+        import data.memory.episodic_memory as em
+
+        entries = [{"id": "e_0", "event": "solo cached entry", "metadata": {}, "time": "2026-08-01T00:00:00Z"}]
+
+        def _fake_encode(text, timeout=None):
+            return np.ones(8, dtype="float32")
+
+        monkeypatch.setattr("data.memory.embeddings.encode_with_timeout", _fake_encode)
+        em._semantic_episode_search(entries, "anything", limit=5)
+
+        ids, vecs = em._load_vec_cache()
+        assert ids == ["e_0"]
+        assert vecs.shape == (1, 8)
+
+
+# ── AC3: system events land in the timeline ──────────────────────────────────
+
+class TestIndexEventLogging:
+    def test_index_repo_logs_exactly_one_index_event(self, tmp_path, monkeypatch):
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "hello.py").write_text("def greet(name):\n    return name\n")
+
+        from interface.cli.main import _direct_index
+        _direct_index(str(tmp_path), embed=False, skip_graph=True)
+
+        from data.memory.episodic_memory import get_history
+        index_events = [
+            e for e in get_history(limit=1000)
+            if e.get("metadata", {}).get("type") == "index_event"
+        ]
+        assert len(index_events) == 1
+        assert "symbols" in index_events[0]["metadata"]
+        assert "files" in index_events[0]["metadata"]
+
+
+# ── AC4: datetime.utcnow() removed ───────────────────────────────────────────
+
+class TestNoDeprecatedUtcnow:
+    def test_log_event_timestamp_is_tz_aware_parseable(self, tmp_path, monkeypatch):
+        from core.config.paths import set_cognirepo_dir
+        set_cognirepo_dir(str(tmp_path / ".cognirepo"))
+
+        import data.memory.episodic_memory as em
+        em._BM25_CORPUS = None
+        em._BM25_INDEX = None
+        em.log_event("test event")
+
+        from datetime import datetime
+        data = em._load()
+        assert len(data) == 1
+        ts = data[0]["time"]
+        # datetime.now(timezone.utc).isoformat() with "Z" suffix must parse cleanly
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        assert parsed.tzinfo is not None
+
+    def test_no_utcnow_call_in_source(self):
+        import inspect
+        import data.memory.episodic_memory as em
+        source = inspect.getsource(em)
+        assert "datetime.utcnow()" not in source

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -88,6 +88,72 @@ class TestKnowledgeGraph:
         assert kg.G.number_of_nodes() == 1
 
 
+class TestKnowledgeGraphIntegrity:
+    """COGNIREPO-201: integrity sweep — orphans + dangling file nodes."""
+
+    def test_clean_graph_reports_zero(self, tmp_path):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        (tmp_path / "auth.py").write_text("def verify_token(): pass\n", encoding="utf-8")
+        kg.add_node("auth.py", NodeType.FILE)
+        kg.add_node("auth.py::verify_token", NodeType.FUNCTION, file="auth.py")
+        kg.add_edge("auth.py::verify_token", "auth.py", EdgeType.DEFINED_IN)
+        report = kg.integrity_report(str(tmp_path))
+        assert report["orphans"] == []
+        assert report["dangling_files"] == []
+        assert report["swept_at"]
+
+    def test_orphan_restricted_to_file_function_class(self, tmp_path):
+        """MEMORY/SESSION/ERROR/QUERY/CONCEPT nodes are legitimately edge-free early on."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType
+        kg = KnowledgeGraph()
+        kg.add_node("orphan_fn", NodeType.FUNCTION, file="ghost.py")
+        kg.add_node("m1", NodeType.MEMORY)
+        kg.add_node("s1", NodeType.SESSION)
+        kg.add_node("e1", NodeType.ERROR)
+        kg.add_node("concept1", NodeType.CONCEPT)
+        report = kg.integrity_report(str(tmp_path))
+        assert report["orphans"] == ["orphan_fn"]
+
+    def test_dangling_file_detected_and_deduped(self, tmp_path):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::fn_a", NodeType.FUNCTION, file="gone.py")
+        kg.add_node("gone.py::fn_b", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::fn_a", "gone.py", EdgeType.DEFINED_IN)
+        kg.add_edge("gone.py::fn_b", "gone.py", EdgeType.DEFINED_IN)
+        report = kg.integrity_report(str(tmp_path))
+        # gone.py never existed under tmp_path — one dangling entry, not three.
+        assert report["dangling_files"] == ["gone.py"]
+
+    def test_repair_apply_removes_dangling_only(self, tmp_path):
+        """AC3: --apply removes danglers only; orphan CONCEPTs untouched."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        kg = KnowledgeGraph()
+        (tmp_path / "live.py").write_text("def keep(): pass\n", encoding="utf-8")
+        kg.add_node("live.py", NodeType.FILE)
+        kg.add_node("live.py::keep", NodeType.FUNCTION, file="live.py")
+        kg.add_edge("live.py::keep", "live.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("orphan_concept", NodeType.CONCEPT, unresolved=True)
+
+        report = kg.integrity_report(str(tmp_path))
+        for f in report["dangling_files"]:
+            kg.remove_file_nodes(f)
+
+        assert kg.node_exists("live.py") and kg.node_exists("live.py::keep")
+        assert not kg.node_exists("gone.py") and not kg.node_exists("gone.py::stale")
+        assert kg.node_exists("orphan_concept")  # untouched — no 'file' attr
+
+        report2 = kg.integrity_report(str(tmp_path))
+        assert report2["dangling_files"] == []
+
+
 class TestKnowledgeGraphCorruptionQuarantine:
     """COGNIREPO-103 AC2: a corrupt graph.pkl is quarantined, not silently overwritten."""
 

--- a/tests/test_graph_repair.py
+++ b/tests/test_graph_repair.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+"""
+tests/test_graph_repair.py — COGNIREPO-201: `cognirepo graph repair` CLI.
+
+Exercises _cmd_graph_repair() against a real KnowledgeGraph (isolated_cognirepo
+fixture chdirs into tmp_path), matching TC-201-1's dry-run-by-default / --apply flow.
+"""
+from __future__ import annotations
+
+
+class TestGraphRepair:
+    def test_dry_run_reports_without_mutating(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_graph_repair
+
+        kg = KnowledgeGraph()
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+        kg.save()
+
+        code = _cmd_graph_repair(apply=False)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "gone.py" in out
+        assert "Dry run" in out
+
+        # Nothing was mutated — reload from disk and confirm the node survives.
+        kg2 = KnowledgeGraph()
+        assert kg2.node_exists("gone.py")
+        assert kg2.node_exists("gone.py::stale")
+
+    def test_apply_prunes_danglers_only(self, isolated_cognirepo, capsys):
+        """AC3: --apply removes danglers only; orphan CONCEPTs untouched; prints counts."""
+        from data.graph.knowledge_graph import KnowledgeGraph, NodeType, EdgeType
+        from interface.cli.main import _cmd_graph_repair
+
+        kg = KnowledgeGraph()
+        with open("live.py", "w", encoding="utf-8") as f:
+            f.write("def keep(): pass\n")
+        kg.add_node("live.py", NodeType.FILE)
+        kg.add_node("live.py::keep", NodeType.FUNCTION, file="live.py")
+        kg.add_edge("live.py::keep", "live.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("gone.py", NodeType.FILE)
+        kg.add_node("gone.py::stale", NodeType.FUNCTION, file="gone.py")
+        kg.add_edge("gone.py::stale", "gone.py", EdgeType.DEFINED_IN)
+
+        kg.add_node("orphan_concept", NodeType.CONCEPT, unresolved=True)
+        kg.save()
+
+        code = _cmd_graph_repair(apply=True)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "Removed 2 node(s)" in out  # gone.py + gone.py::stale
+
+        kg2 = KnowledgeGraph()
+        assert kg2.node_exists("live.py") and kg2.node_exists("live.py::keep")
+        assert not kg2.node_exists("gone.py") and not kg2.node_exists("gone.py::stale")
+        assert kg2.node_exists("orphan_concept")
+
+    def test_no_dangling_files_reports_clean(self, isolated_cognirepo, capsys):
+        from data.graph.knowledge_graph import KnowledgeGraph
+        from interface.cli.main import _cmd_graph_repair
+
+        KnowledgeGraph().save()
+
+        code = _cmd_graph_repair(apply=False)
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "no dangling file nodes found" in out

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -87,6 +87,48 @@ class TestHybridRetriever:
         assert scores == sorted(scores, reverse=True)
 
 
+class TestGraphScoreSimilarToWeighting:
+    """COGNIREPO-202 AC4 — SIMILAR_TO is weighted into _graph_score, not treated as a
+    full-strength structural edge (non-regression: a real 1-hop edge still outscores it)."""
+
+    def test_similar_to_only_link_discounted_below_real_edge(self):
+        from data.graph.knowledge_graph import EdgeType, NodeType
+        from intelligence.retrieval.hybrid import HybridRetriever
+
+        r = HybridRetriever()
+        r.graph.add_node("a.py::verify_a", NodeType.FUNCTION, file="a.py")
+        r.graph.add_node("b.py::verify_b", NodeType.FUNCTION, file="b.py")
+        r.graph.add_edge("a.py::verify_a", "b.py::verify_b", EdgeType.SIMILAR_TO, weight=0.9)
+        r.graph.add_edge("b.py::verify_b", "a.py::verify_a", EdgeType.SIMILAR_TO, weight=0.9)
+        r._undirected = r.graph.G.to_undirected()  # rebuild after manual edits
+
+        similar_only_score = r._graph_score({"_symbol": "b.py::verify_b"}, ["a.py::verify_a"])
+
+        r.graph.add_node("c.py::verify_c", NodeType.FUNCTION, file="c.py")
+        r.graph.add_edge("a.py::verify_a", "c.py::verify_c", EdgeType.CALLED_BY)
+        r.graph.add_edge("c.py::verify_c", "a.py::verify_a", EdgeType.CALLS)
+        r._undirected = r.graph.G.to_undirected()
+
+        real_edge_score = r._graph_score({"_symbol": "c.py::verify_c"}, ["a.py::verify_a"])
+
+        assert 0.0 < similar_only_score < real_edge_score == 0.5
+
+    def test_similar_to_plus_real_edge_not_discounted(self):
+        """When a real structural edge ALSO connects the pair, no discount applies."""
+        from data.graph.knowledge_graph import EdgeType, NodeType
+        from intelligence.retrieval.hybrid import HybridRetriever
+
+        r = HybridRetriever()
+        r.graph.add_node("a.py::verify_a", NodeType.FUNCTION, file="a.py")
+        r.graph.add_node("b.py::verify_b", NodeType.FUNCTION, file="b.py")
+        r.graph.add_edge("a.py::verify_a", "b.py::verify_b", EdgeType.CALLED_BY)
+        r.graph.add_edge("b.py::verify_b", "a.py::verify_a", EdgeType.SIMILAR_TO, weight=0.9)
+        r._undirected = r.graph.G.to_undirected()
+
+        score = r._graph_score({"_symbol": "b.py::verify_b"}, ["a.py::verify_a"])
+        assert score == 0.5
+
+
 class TestVectorRetrieveSourcePreservation:
     """COGNIREPO-D07: _vector_retrieve() must report the real stored source
     (previously hardcoded "semantic" for every vector-backend hit)."""

--- a/tests/test_indexer_multilang.py
+++ b/tests/test_indexer_multilang.py
@@ -219,6 +219,267 @@ class TestJavaIndexing:
         assert any(r["file"] == "Repo.java" for r in results)
 
 
+# ── Go (tree-sitter-go) ────────────────────────────────────────────────────────
+
+def _callers_of(graph, name: str) -> list[str]:
+    """Mirror of interface/server/mcp_server.py::who_calls's graph-only lookup —
+    successors of the symbol/stub-resolved node connected via a CALLS edge."""
+    from data.graph.knowledge_graph import EdgeType
+    node = f"symbol::{name}"
+    if not graph.G.has_node(node):
+        candidates = [
+            n for n in graph.G.nodes()
+            if n.endswith(f"::{name}") and not n.startswith("symbol::")
+        ]
+        if not candidates:
+            return []
+        node = candidates[0]
+    return [
+        succ for succ in graph.G.successors(node)
+        if graph.G[node][succ].get("rel") == EdgeType.CALLS
+    ]
+
+
+class TestGoIndexing:
+    """COGNIREPO-203 AC1 — Go selector_expression (receiver-qualified method) calls
+    must resolve through who_calls, not just plain function calls."""
+
+    _GO_FIXTURE = """\
+        package main
+
+        type Server struct{}
+
+        func (s *Server) Start() {
+            s.listen()
+            logStart()
+        }
+
+        func (s *Server) listen() {
+            accept()
+        }
+
+        func (s *Server) Stop() {
+            s.cleanup()
+        }
+
+        func (s *Server) cleanup() {}
+
+        func accept() {
+            handle()
+        }
+
+        func handle() {
+            process()
+        }
+
+        func process() {
+            validate()
+            save()
+        }
+
+        func validate() {}
+        func save() {}
+        func logStart() {}
+
+        func main() {
+            s := &Server{}
+            s.Start()
+            s.Stop()
+            setup()
+        }
+
+        func setup() {}
+    """
+
+    # Hand-verified callee -> caller pairs (11 call sites, per AC1's "≥10 incl. method calls").
+    _EXPECTED_CALLERS = {
+        "listen": "Start", "logStart": "Start", "cleanup": "Stop", "accept": "listen",
+        "handle": "accept", "process": "handle", "validate": "process", "save": "process",
+        "Start": "main", "Stop": "main", "setup": "main",
+    }
+
+    def test_go_functions_and_methods_extracted(self, fresh_indexer, tmp_path, monkeypatch):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        record = fresh_indexer.index_file("main.go", str(tmp_path / "main.go"))
+        names = [s["name"] for s in record["symbols"]]
+        assert "Server" in names
+        assert "Start" in names and "listen" in names and "Stop" in names
+
+    def test_go_selector_expression_call_captured(self, fresh_indexer, tmp_path, monkeypatch):
+        """Regression guard for the field-vs-property tree-sitter bug: Go's
+        selector_expression names its method field "field", not "property" (the JS
+        name) — before the fix, `s.listen()` inside Start() was silently dropped."""
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        record = fresh_indexer.index_file("main.go", str(tmp_path / "main.go"))
+        start_sym = next(s for s in record["symbols"] if s["name"] == "Start")
+        assert "listen" in start_sym["calls"]
+
+    def test_who_calls_resolves_at_least_90_percent_of_hand_verified_callers(
+        self, fresh_indexer, tmp_path, monkeypatch
+    ):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "main.go", self._GO_FIXTURE)
+        fresh_indexer.index_repo(str(tmp_path))
+
+        resolved = 0
+        for callee, expected_caller in self._EXPECTED_CALLERS.items():
+            callers = _callers_of(fresh_indexer.graph, callee)
+            if any(c.endswith(f"::{expected_caller}") for c in callers):
+                resolved += 1
+        ratio = resolved / len(self._EXPECTED_CALLERS)
+        assert ratio >= 0.90, f"only {resolved}/{len(self._EXPECTED_CALLERS)} callers resolved"
+
+    def test_go_imports_edge_to_local_package(self, fresh_indexer, tmp_path, monkeypatch):
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.21\n", encoding="utf-8")
+        util_dir = tmp_path / "util"
+        util_dir.mkdir()
+        _write(util_dir, "util.go", """\
+            package util
+
+            func Helper() {}
+        """)
+        _write(tmp_path, "main.go", """\
+            package main
+
+            import "example.com/demo/util"
+
+            func main() {
+                util.Helper()
+            }
+        """)
+        from data.graph.knowledge_graph import EdgeType
+        fresh_indexer.index_repo(str(tmp_path))
+        assert fresh_indexer.graph.G.has_edge("main.go", "util/util.go")
+        edge = fresh_indexer.graph.G["main.go"]["util/util.go"]
+        assert edge.get("rel") == EdgeType.IMPORTS
+
+    def test_go_external_import_not_resolved_locally(self, fresh_indexer, tmp_path, monkeypatch):
+        """stdlib/third-party imports (no go.mod match) must not fabricate edges."""
+        pytest.importorskip("tree_sitter_go")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "go.mod").write_text("module example.com/demo\n\ngo 1.21\n", encoding="utf-8")
+        _write(tmp_path, "main.go", """\
+            package main
+
+            import "fmt"
+
+            func main() {
+                fmt.Println("hi")
+            }
+        """)
+        fresh_indexer.index_repo(str(tmp_path))
+        file_node = fresh_indexer.graph.G.nodes.get("main.go", {})
+        assert file_node  # file node itself still exists
+        assert fresh_indexer.graph.G.out_degree("main.go") == 0
+
+
+# ── Dynamic dispatch annotation (COGNIREPO-203 AC2) ────────────────────────────
+
+class TestDynamicDispatchAnnotation:
+    def test_celery_task_decorator_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "tasks.py", """\
+            from celery import shared_task
+
+            @shared_task
+            def send_email(to):
+                pass
+
+            @app.task
+            def process_order(order_id):
+                pass
+
+            def plain_function():
+                pass
+        """)
+        record = fresh_indexer.index_file("tasks.py", str(src))
+        by_name = {s["name"]: s for s in record["symbols"]}
+        assert by_name["send_email"]["dispatch"] == "dynamic"
+        assert by_name["process_order"]["dispatch"] == "dynamic"
+        assert by_name["plain_function"].get("dispatch") is None
+
+    def test_register_call_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        """Generic plugin-registry pattern (Ansible-module-style self-registration)."""
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "plugins.py", """\
+            def setup_plugin():
+                registry.register(MyPlugin)
+        """)
+        record = fresh_indexer.index_file("plugins.py", str(src))
+        sym = next(s for s in record["symbols"] if s["name"] == "setup_plugin")
+        assert sym["dispatch"] == "dynamic"
+
+    def test_init_subclass_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        src = _write(tmp_path, "plugin_base.py", """\
+            class PluginBase:
+                def __init_subclass__(cls, **kwargs):
+                    super().__init_subclass__(**kwargs)
+        """)
+        record = fresh_indexer.index_file("plugin_base.py", str(src))
+        sym = next(s for s in record["symbols"] if s["name"] == "__init_subclass__")
+        assert sym["dispatch"] == "dynamic"
+
+    def test_dispatch_dynamic_relates_to_concept_node(self, fresh_indexer, tmp_path, monkeypatch):
+        """dispatch:"dynamic" symbols get a RELATES_TO edge to the dynamic_dispatch
+        CONCEPT node, so subgraph()/graph queries surface them without a fabricated
+        CALLS edge (risk note: annotation-only)."""
+        monkeypatch.chdir(tmp_path)
+        from data.graph.knowledge_graph import EdgeType
+        src = _write(tmp_path, "tasks.py", """\
+            @shared_task
+            def send_email(to):
+                pass
+        """)
+        fresh_indexer.index_file("tasks.py", str(src))
+        sym_node = "tasks.py::send_email"
+        assert fresh_indexer.graph.G.nodes[sym_node].get("dispatch") == "dynamic"
+        assert fresh_indexer.graph.G.has_edge(sym_node, "concept::dynamic_dispatch")
+        assert fresh_indexer.graph.G[sym_node]["concept::dynamic_dispatch"]["rel"] == EdgeType.RELATES_TO
+
+    def test_entry_points_pyproject_tagged_dynamic(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            """\
+            [project.entry-points."myapp.plugins"]
+            widget = "myapp.plugins.widget:load_widget"
+            """,
+            encoding="utf-8",
+        )
+        _write(tmp_path, "widget.py", """\
+            def load_widget():
+                pass
+        """)
+        fresh_indexer.index_repo(str(tmp_path))
+        assert fresh_indexer.graph.G.nodes["widget.py::load_widget"].get("dispatch") == "dynamic"
+
+    def test_no_fabricated_calls_edge_from_dispatch_tag(self, fresh_indexer, tmp_path, monkeypatch):
+        """Risk note: dispatch heuristics are annotation-only — no synthetic CALLS
+        edge should appear between a dispatch:"dynamic" symbol and anything else
+        purely because of the tag."""
+        monkeypatch.chdir(tmp_path)
+        from data.graph.knowledge_graph import EdgeType
+        src = _write(tmp_path, "tasks.py", """\
+            @shared_task
+            def send_email(to):
+                pass
+        """)
+        fresh_indexer.index_file("tasks.py", str(src))
+        sym_node = "tasks.py::send_email"
+        rels = {
+            fresh_indexer.graph.G[sym_node][succ].get("rel")
+            for succ in fresh_indexer.graph.G.successors(sym_node)
+        }
+        assert EdgeType.CALLS not in rels
+
+
 # ── language_registry ─────────────────────────────────────────────────────────
 
 class TestLanguageRegistry:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -206,6 +206,16 @@ class TestNewMCPTools:
         result = graph_stats()
         assert isinstance(result["top_concepts"], list)
 
+    def test_graph_stats_integrity_block(self):
+        """COGNIREPO-201 AC1: graph_stats returns integrity {orphans, dangling_files, swept_at}."""
+        from interface.server.mcp_server import graph_stats
+        result = graph_stats()
+        assert "integrity" in result
+        integrity = result["integrity"]
+        assert isinstance(integrity["orphans"], list)
+        assert isinstance(integrity["dangling_files"], list)
+        assert integrity["swept_at"]
+
     def test_manifest_includes_new_tools(self):
         from interface.server.mcp_server import _build_manifest
         manifest = _build_manifest()

--- a/tests/test_similarity_edges.py
+++ b/tests/test_similarity_edges.py
@@ -1,0 +1,188 @@
+# pylint: disable=missing-docstring, unnecessary-lambda, import-outside-toplevel, too-few-public-methods, duplicate-code
+# pylint: disable=redefined-outer-name, unused-argument, broad-exception-caught, protected-access
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_similarity_edges.py — COGNIREPO-202 acceptance criteria.
+
+Uses the session-scoped mock_embeddings fixture (tests/conftest.py): each embed text gets
+a one-hot vector keyed on the FIRST matching keyword from a fixed list ("jwt", "docker", …).
+Two symbols whose embed text both hit the same keyword get IDENTICAL vectors (cosine 1.0,
+well above the 0.80 threshold); symbols hitting different keywords are orthogonal (cosine 0.0).
+This makes near-duplicate vs. unrelated deterministic without a real embedding model.
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def fresh_indexer(isolated_cognirepo):
+    from data.graph.knowledge_graph import KnowledgeGraph
+    from intelligence.indexer.ast_indexer import ASTIndexer
+    from intelligence.indexer.language_registry import clear_cache
+    clear_cache()
+    kg = KnowledgeGraph()
+    return ASTIndexer(graph=kg)
+
+
+def _write(tmp: Path, name: str, content: str) -> Path:
+    p = tmp / name
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def _similar_to_edges(graph):
+    from data.graph.knowledge_graph import EdgeType
+    return [
+        (u, v) for u, v, d in graph.G.edges(data=True)
+        if d.get("rel") == EdgeType.SIMILAR_TO
+    ]
+
+
+class TestSimilarityEdgeCreation:
+    def test_near_duplicate_functions_get_similar_to_edge(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "a.py", '''\
+            def verify_a():
+                """jwt token check"""
+                pass
+        ''')
+        _write(tmp_path, "b.py", '''\
+            def verify_b():
+                """jwt token check"""
+                pass
+        ''')
+
+        fresh_indexer.index_repo(str(tmp_path))
+        edges = _similar_to_edges(fresh_indexer.graph)
+
+        assert ("a.py::verify_a", "b.py::verify_b") in edges
+        assert ("b.py::verify_b", "a.py::verify_a") in edges  # both directions
+
+        # weight is the cosine similarity, recorded ≥ the 0.80 threshold
+        w = fresh_indexer.graph.G["a.py::verify_a"]["b.py::verify_b"]["weight"]
+        assert w >= 0.80
+
+    def test_subgraph_shows_counterpart_from_either_side(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "a.py", '''\
+            def verify_a():
+                """jwt token check"""
+                pass
+        ''')
+        _write(tmp_path, "b.py", '''\
+            def verify_b():
+                """jwt token check"""
+                pass
+        ''')
+        fresh_indexer.index_repo(str(tmp_path))
+
+        sub_a = fresh_indexer.graph.subgraph_around("a.py::verify_a", radius=1)
+        sub_b = fresh_indexer.graph.subgraph_around("b.py::verify_b", radius=1)
+        assert "b.py::verify_b" in {n["node_id"] for n in sub_a["nodes"]}
+        assert "a.py::verify_a" in {n["node_id"] for n in sub_b["nodes"]}
+
+    def test_unrelated_symbols_get_no_edge(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "a.py", '''\
+            def verify_a():
+                """jwt token check"""
+                pass
+        ''')
+        _write(tmp_path, "b.py", '''\
+            def build_image():
+                """docker build helper"""
+                pass
+        ''')
+
+        fresh_indexer.index_repo(str(tmp_path))
+        edges = _similar_to_edges(fresh_indexer.graph)
+        assert edges == []
+
+    def test_same_file_pair_never_gets_edge(self, fresh_indexer, tmp_path, monkeypatch):
+        """DEFINED_IN already relates same-file symbols — SIMILAR_TO would be redundant."""
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "a.py", '''\
+            def verify_a():
+                """jwt token check"""
+                pass
+
+            def verify_a2():
+                """jwt token check"""
+                pass
+        ''')
+
+        fresh_indexer.index_repo(str(tmp_path))
+        edges = _similar_to_edges(fresh_indexer.graph)
+        assert edges == []
+
+    def test_cap_enforced_at_five_per_node(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        hub_file = _write(tmp_path, "hub.py", '''\
+            def verify_hub():
+                """jwt token check"""
+                pass
+        ''')
+        for i in range(8):
+            _write(tmp_path, f"dup{i}.py", f'''\
+                def verify_{i}():
+                    """jwt token check"""
+                    pass
+            ''')
+
+        fresh_indexer.index_repo(str(tmp_path))
+        out_degree = sum(
+            1 for _, _, d in fresh_indexer.graph.G.out_edges("hub.py::verify_hub", data=True)
+            if d.get("rel") == "SIMILAR_TO"
+        )
+        assert out_degree <= 5
+
+
+class TestSimilarityEdgeGate:
+    def test_gate_off_yields_zero_edges(self, fresh_indexer, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cognirepo_dir = tmp_path / ".cognirepo"
+        cognirepo_dir.mkdir(exist_ok=True)
+        (cognirepo_dir / "config.json").write_text(
+            json.dumps({"indexing": {"similarity_edges": False}}), encoding="utf-8"
+        )
+        _write(tmp_path, "a.py", '''\
+            def verify_a():
+                """jwt token check"""
+                pass
+        ''')
+        _write(tmp_path, "b.py", '''\
+            def verify_b():
+                """jwt token check"""
+                pass
+        ''')
+
+        fresh_indexer.index_repo(str(tmp_path))
+        assert _similar_to_edges(fresh_indexer.graph) == []
+
+    def test_gate_off_graph_still_loads_fine(self, fresh_indexer, tmp_path, monkeypatch):
+        """Existing graphs load fine either way — unknown rel values are already tolerated."""
+        monkeypatch.chdir(tmp_path)
+        cognirepo_dir = tmp_path / ".cognirepo"
+        cognirepo_dir.mkdir(exist_ok=True)
+        (cognirepo_dir / "config.json").write_text(
+            json.dumps({"indexing": {"similarity_edges": False}}), encoding="utf-8"
+        )
+        _write(tmp_path, "a.py", "def foo(): pass\n")
+
+        summary = fresh_indexer.index_repo(str(tmp_path))
+        assert summary["similarity_edges"] == 0
+
+        fresh_indexer.graph.save()
+        from data.graph.knowledge_graph import KnowledgeGraph
+        reloaded = KnowledgeGraph()
+        assert reloaded.G.number_of_nodes() > 0

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,178 @@
+# pylint: disable=missing-docstring, redefined-outer-name, protected-access
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_timeline.py — COGNIREPO-204 acceptance criteria.
+
+data/memory/timeline.py merges episodic (live + archive), session-exchange files,
+and behaviour error patterns into one chronologically ordered view, plus a
+deterministic template rollup.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.config.paths import get_path
+
+
+def _write_session(sessions_dir: Path, session_id: str, created_at: str, user_msg: str) -> None:
+    (sessions_dir / f"{session_id}.json").write_text(
+        json.dumps({
+            "session_id": session_id,
+            "created_at": created_at,
+            "model": "claude-sonnet-5",
+            "messages": [
+                {"role": "user", "content": user_msg},
+                {"role": "assistant", "content": "ack"},
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+
+def _log_episode(event: str, ts_override: str, metadata: dict | None = None) -> None:
+    """Log via the real episodic_memory module, then force a specific timestamp
+    (log_event always stamps "now" — tests need controlled, distinct timestamps
+    to assert ordering deterministically)."""
+    from data.memory.episodic_memory import log_event, _load, _save  # pylint: disable=import-outside-toplevel
+    log_event(event, metadata)
+    data = _load()
+    data[-1]["time"] = ts_override
+    _save(data)
+
+
+def _record_error(error_type: str, ts_override: str) -> None:
+    from data.graph.knowledge_graph import KnowledgeGraph  # pylint: disable=import-outside-toplevel
+    from data.graph.behaviour_tracker import BehaviourTracker  # pylint: disable=import-outside-toplevel
+    bt = BehaviourTracker(KnowledgeGraph())
+    bt.record_error(error_type, file_path="app.py", message="boom")
+    bt.data["error_patterns"][error_type]["last_seen"] = ts_override
+    bt.save()
+
+
+class TestTimelineMerge:
+    def test_merge_returns_seven_ordered_entries_ac1(self, tmp_path, monkeypatch):
+        """AC1: 2 sessions + 3 episodes + 1 decision + 1 error -> 7 ordered entries;
+        rollup names the decision and the error."""
+        from data.memory import timeline
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "s1", "2026-08-01T10:00:00+00:00", "how does auth work")
+        _write_session(sessions_dir, "s2", "2026-08-02T10:00:00+00:00", "fix the flaky test")
+
+        _log_episode("indexed repo", "2026-08-01T11:00:00+00:00")
+        _log_episode("ran benchmark", "2026-08-02T11:00:00+00:00")
+        _log_episode("reviewed PR", "2026-08-03T11:00:00+00:00")
+        _log_episode(
+            "decision: use FAISS for vector search", "2026-08-03T12:00:00+00:00",
+            metadata={"type": "decision", "summary": "use FAISS for vector search"},
+        )
+        _record_error("ImportError", "2026-08-03T13:00:00+00:00")
+
+        entries = timeline.merge(since="30d", limit=100)
+        assert len(entries) == 7
+        kinds = [e["kind"] for e in entries]
+        assert kinds.count("session") == 2
+        assert kinds.count("episode") == 3
+        assert kinds.count("decision") == 1
+        assert kinds.count("error") == 1
+
+        # newest first
+        timestamps = [e["ts"] for e in entries]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+        rollup = timeline.rollup(entries)
+        assert rollup["total"] == 7
+        assert rollup["counts"] == {"session": 2, "episode": 3, "decision": 1, "error": 1}
+        assert any("FAISS" in d for d in rollup["top_decisions"])
+        assert any("ImportError" in e for e in rollup["top_errors"])
+
+    def test_include_archived_default_excludes_ac2(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        from data.memory.episodic_memory import log_event
+
+        log_event("live entry")
+        archive_path = get_path("memory/episodic_archive.json")
+        Path(archive_path).write_text(json.dumps([{
+            "id": "e_archived_1", "event": "archived entry",
+            "metadata": {}, "time": "2026-01-01T00:00:00+00:00",
+        }]), encoding="utf-8")
+
+        default_entries = timeline.merge(since="3650d", include_archived=False)
+        assert "archived entry" not in [e["summary"] for e in default_entries]
+
+        archived_entries = timeline.merge(since="3650d", include_archived=True)
+        assert "archived entry" in [e["summary"] for e in archived_entries]
+
+    def test_since_filters_old_entries(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        from datetime import datetime, timezone
+
+        monkeypatch.setattr(timeline, "_now", lambda: datetime(2026, 8, 10, tzinfo=timezone.utc))
+        _log_episode("very old event", "2020-01-01T00:00:00+00:00")
+        _log_episode("recent event", "2026-08-05T00:00:00+00:00")
+
+        entries = timeline.merge(since="30d")
+        summaries = [e["summary"] for e in entries]
+        assert "recent event" in summaries
+        assert "very old event" not in summaries
+
+    def test_deterministic_byte_identical_output_ac3(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+
+        _write_session(Path(get_path("sessions")), "s1", "2026-08-01T10:00:00+00:00", "hello")
+        _log_episode("event a", "2026-08-01T11:00:00+00:00")
+        _log_episode("event b", "2026-08-01T11:00:00+00:00")  # same ts as "event a" — tie
+        _record_error("TypeError", "2026-08-01T12:00:00+00:00")
+
+        first = json.dumps(timeline.merge(since="30d"), sort_keys=True)
+        second = json.dumps(timeline.merge(since="30d"), sort_keys=True)
+        assert first == second
+
+    def test_empty_store_returns_empty_list(self, tmp_path, monkeypatch):
+        from data.memory import timeline
+        assert timeline.merge() == []
+
+
+class TestSessionParserExtraction:
+    """Risk note: session-parser extraction must not change get_session_history
+    behavior (golden test)."""
+
+    def test_get_session_history_matches_parse_session_file(self, tmp_path, monkeypatch):
+        from data.memory.timeline import parse_session_file
+        from interface.server.mcp_server import get_session_history
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "golden", "2026-08-01T10:00:00+00:00", "test query")
+
+        via_tool = get_session_history(limit=5)
+        assert len(via_tool) == 1
+
+        via_parser = parse_session_file(str(sessions_dir / "golden.json"))
+        assert via_tool[0] == via_parser
+
+    def test_get_session_history_unaffected_by_current_json(self, tmp_path, monkeypatch):
+        from interface.server.mcp_server import get_session_history
+
+        sessions_dir = Path(get_path("sessions"))
+        _write_session(sessions_dir, "real", "2026-08-01T10:00:00+00:00", "hi")
+        (sessions_dir / "current.json").write_text('{"pointer": "real"}', encoding="utf-8")
+
+        results = get_session_history(limit=10)
+        assert len(results) == 1
+        assert results[0]["session_id"] == "real"
+
+
+class TestBootstrapTimelineDigest:
+    def test_bootstrap_includes_recent_timeline(self, tmp_path, monkeypatch):
+        from interface.server.mcp_server import get_agent_bootstrap
+
+        _write_session(Path(get_path("sessions")), "s1", "2026-08-01T10:00:00+00:00", "hi")
+        result = get_agent_bootstrap()
+        assert "recent_timeline" in result
+        assert isinstance(result["recent_timeline"], list)

--- a/version.yml
+++ b/version.yml
@@ -5,7 +5,7 @@
 
 project:
   name: cognirepo
-  version: "2.0.1"
+  version: "2.1.0"
   description: "Local cognitive infrastructure layer for AI agents"
   license: MIT
   python_requires: ">=3.11,<3.15"


### PR DESCRIPTION
Ticket: `JIRA/EPIC-KGEpisodicHardening-200/COGNIREPO-200.md`

## Summary
Epic COGNIREPO-200 (Knowledge Graph & Episodic Memory Hardening, Phase 1) — 5 stories,
all signed off:

- **201** — graph integrity sweep (`orphans`/`dangling_files`/`swept_at` in `graph_stats`,
  `doctor` warning, `cognirepo graph repair`)
- **202** — `SIMILAR_TO` edges via FAISS k-NN at index time, cost-gated below a 20k-symbol
  ceiling
- **203** — Go call-graph completion (`selector_expression` field-name bug, recursion cap
  12→60, `IMPORTS` edges) + dynamic-dispatch annotation
- **204** — unified timeline (`data/memory/timeline.py::merge()`/`rollup()`), folded into
  `get_agent_bootstrap` as a 0-manifest-token `recent_timeline` digest
- **205** — episodic archive search, persistent embedding cache for the semantic fallback,
  automatic `index_event` logging on `index-repo`/`org rewire`, `decision_nudge`,
  `datetime.utcnow()` fix

## Test plan
- Full automated suite green throughout (1354 passed, 9 skipped as of the last story).
- Epic-level e2e suite (`JIRA/EPIC-KGEpisodicHardening-200/COGNIREPO-200-TEST_SUITE.md`),
  both PASS:
  - **E2E-200-1** (crosses 201+204+205): single `merge(include_archived=True)` call
    against `cognirepo_test_repo/medium/celery` returns all 27 seeded/rotated entries,
    27/27 unique refs, rollup names the decision and the recurring error.
  - **E2E-200-2** (crosses 201+202+203): `who_calls`/`graph_stats` verified fresh against
    `cognirepo_test_repo/advanced/moby` (116,532 symbols, 0 orphans); `SIMILAR_TO`
    verified on `medium/celery` instead — moby's symbol count is by design above
    `_SIMILARITY_SYMBOL_CEILING` (20,000), so no similarity edges build there without an
    explicit config override. Not a defect.
- `CHANGELOG.md` backfilled for 202/203/204/205 (only 201 had an entry under
  `[Unreleased]`); version bumped 2.0.1 → 2.1.0 via `version.yml` +
  `scripts/sync_version.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)