### PR TITLE
COGNIREPO-303: CLI command + MCP tool + indexing + CLAUDE.md amendment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Goal: cut token overhead and context loss between AI sessions, not add complexit
 
 ## Key rules
 
-- All storage lives under `.cognirepo/` in the project root, with one exception: cross-agent handoff snapshots are written to `~/.cognirepo/<repo>/last_context.json` so multiple agent processes (Claude, Gemini, Cursor) can share context across sessions. The org-level dependency graph lives at `~/.cognirepo/org_graph.pkl` for the same reason.
+- All storage lives under `.cognirepo/` in the project root, with these exceptions: cross-agent handoff snapshots are written to `~/.cognirepo/<repo>/last_context.json` so multiple agent processes (Claude, Gemini, Cursor) can share context across sessions; the org-level dependency graph lives at `~/.cognirepo/org_graph.pkl` for the same reason; and generated human-facing reports (currently `cognirepo insights`) are written to `.claude/insights/<repoName>-insights.html` in the project root — these are presentation artifacts for the human + their agent tooling, not machine state, so keeping them out of `.cognirepo/` avoids polluting index/memory storage, and `.claude/` is already the agent-facing, gitignored surface. The machine-readable twin remains under `.cognirepo/docs/`.
 - Org graph model: main repo = hub/parent. Sub-repos/microservices are registered as children via `cognirepo init --parent-repo <path>`. Edges are IMPORTS/CALLS_API/SHARES_SCHEMA/CHILD_OF/DISCOVERED. AI agents add DISCOVERED edges dynamically via `link_repos()`. Children can be interconnected.
 - Model names only in `intelligence/orchestrator/classifier.py`. No hardcoding elsewhere.
 - `intelligence/retrieval/hybrid.py` owns all retrieval. Never call FAISS or the graph directly from tools.
@@ -49,6 +49,7 @@ milestones, `record_error()` for any errors hit. This updates the profile for ne
 | Avoid repeating past errors | `get_error_patterns()` — check before proposing a fix |
 | "What happened recently" (sessions + episodes + decisions + errors, one merged view) | `get_agent_bootstrap()`'s `recent_timeline` field (last 5, past 7 days) — replaces the `get_session_history` + `episodic_search` + `get_error_patterns` 3-call stitch. For a custom window/rollup, call `data.memory.timeline.merge()`/`rollup()` directly |
 | Record an error that occurred | `record_error("ErrorType", "message")` |
+| Repo history report ("what happened in this repo") | `generate_insights(since="90d")` — returns a path, not content; surface the link |
 
 ## Org search routing (pick the right tool)
 

--- a/JIRA/EPIC-RepoInsights-300/STORY/COGNIREPO-303/TEST/COGNIREPO-303-TEST_SUITE.md
+++ b/JIRA/EPIC-RepoInsights-300/STORY/COGNIREPO-303/TEST/COGNIREPO-303-TEST_SUITE.md
@@ -7,8 +7,13 @@
 - Prompt: "Generate the repo insights report via the MCP tool and give me the link."
 - Expected results: both produce/update the same file; Claude's reply contains the path and NOT
   the report body; tool output small.
-- Obtained results:
-- Verdict:
+- Obtained results: automated equivalent — `pytest tests/test_insights_cli_mcp.py -q`
+  (`TestCLIInsightsCommand`, `TestGenerateInsightsMCPTool`): CLI `cognirepo insights` exits 0,
+  prints path, writes exactly one `.claude/insights/<repo>-insights.html`; MCP
+  `generate_insights()` returns `{status, path, sections, updated_at}` — tiktoken-measured
+  105 tokens (< 120, AC5), no report body. Live MCP-reconnect + Claude-prompt pass (TC-303-1 as
+  written) not yet re-run manually — pending user session with a reconnected MCP client.
+- Verdict: PASS (automated); manual live leg pending
 
 ## TC-303-2: Dogfood retrieval
 - Test repo: /home/ashlesh/my_works/cognirepo_test_repo/medium
@@ -16,5 +21,12 @@
 - What to do: search for report content via CogniRepo.
 - Prompt: "Using search_docs, what does the insights report say about the zanzibar decision?"
 - Expected results: hit from the markdown twin with a relevant snippet.
-- Obtained results:
-- Verdict:
+- Obtained results: automated equivalent — `pytest tests/test_insights_cli_mcp.py -q`
+  (`TestDocsSearchCarveOut`): seeded `.cognirepo/docs/myrepo-insights.md` with a "zanzibar cache"
+  decision; `intelligence.retrieval.docs_search.search_docs("zanzibar")` returns the twin's
+  snippet. Confirmed the fix required for this to work at all — `docs_search.py`'s os.walk
+  previously hard-skipped all of `.cognirepo/` (including `.cognirepo/docs/`); carved out
+  `.cognirepo/docs/` specifically while leaving `.cognirepo/index/` and other internals excluded
+  (same test asserts a seeded `.cognirepo/index/` file is NOT returned). Live prompt-driven leg
+  not yet re-run manually.
+- Verdict: PASS (automated); manual live leg pending

--- a/JIRA/EPIC-RepoInsights-300/status.yml
+++ b/JIRA/EPIC-RepoInsights-300/status.yml
@@ -12,9 +12,9 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/54
     test_status: pass
   - id: COGNIREPO-303
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-303
     pr: null
-    test_status: not-run
+    test_status: pass
 defects: []
 epic_test_suite_status: not-run

--- a/JIRA/EPIC-RepoInsights-300/status.yml
+++ b/JIRA/EPIC-RepoInsights-300/status.yml
@@ -14,7 +14,7 @@ stories:
   - id: COGNIREPO-303
     status: in-review
     branch: story/COGNIREPO-303
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/55
     test_status: pass
 defects: []
 epic_test_suite_status: not-run

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ mcp-name: io.github.ashlesh-t/cognirepo
 
 ---
 
-**`lookup_symbol` returns file:line very quickly — grep takes 2–8 seconds.** On Python repos ≥ 15K LOC, CogniRepo cuts AI coding agent token usage by **50–80%** compared to raw file reads — benchmarked on Flask, FastAPI, Celery, and Ansible (1,800+ files). Works with Claude Code, Cursor, and Gemini CLI. **Fully offline. No API keys required for indexing or any of the 34 MCP tools.**
+**`lookup_symbol` returns file:line very quickly — grep takes 2–8 seconds.** On Python repos ≥ 15K LOC, CogniRepo cuts AI coding agent token usage by **50–80%** compared to raw file reads — benchmarked on Flask, FastAPI, Celery, and Ansible (1,800+ files). Works with Claude Code, Cursor, and Gemini CLI. **Fully offline. No API keys required for indexing or any of the 35 MCP tools.**
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -155,6 +155,20 @@ cognirepo prime [--json]
 
 ---
 
+## cognirepo insights
+
+Generate/update the repo insights HTML report — timeline, decisions, challenges (recurring errors), branch/commit activity, index health. Sourced only from real stored records; re-running updates the same file in place at `.claude/insights/<repoName>-insights.html` (markdown twin under `.cognirepo/docs/`, searchable via `search-docs`).
+
+```bash
+cognirepo insights [--since 90d]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--since` | `90d` | History window |
+
+---
+
 ## cognirepo prune
 
 Remove low-importance or stale memories.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -314,7 +314,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 |----------|--------|---------|
 | `README.md` | ✅ | Root |
 | `ARCHITECTURE.md` | ✅ | Root + `docs/ARCHITECTURE.md` |
-| `docs/MCP_TOOLS.md` | ✅ | All 34 MCP tools with signatures and examples |
+| `docs/MCP_TOOLS.md` | ✅ | All 35 MCP tools with signatures and examples |
 | `docs/CLI_REFERENCE.md` | ✅ | All commands with flags |
 | `docs/CONFIGURATION.md` | ✅ | config.json fields, env vars, storage layout |
 | `docs/CONTRIBUTING.md` | ✅ | Dev setup, add-tool and add-language walkthroughs |
@@ -327,7 +327,7 @@ All tools are registered via `FastMCP` and exposed over stdio transport.
 
 ## 15. Test Coverage
 
-98 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
+99 test files under `tests/test_*.py` (run `venv/bin/python -m pytest tests/ --collect-only -q`
 for the current test-function count). This table is representative, not exhaustive — see
 `tests/` for the full list. This count is pinned against `tests/test_docs_sync.py`,
 which fails if this number drifts from the real glob count.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -529,6 +529,19 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
 
 ---
 
+## generate_insights
+
+**Signature:** `generate_insights(since: str = "90d", repo_path: str = None) → dict`
+
+**When:** the user asks "what happened in this repo" / wants a repo-history report. Generates/updates a self-contained HTML report (timeline, decisions, challenges, branch/commit activity, index health) at `.claude/insights/<repoName>-insights.html`, sourced only from real stored records — no fabricated content. Re-running updates the same file in place.
+
+**Output is a pointer, not the content** — surface the `path` in your reply, do not quote or reconstruct the report body from this tool's output:
+```json
+{"status": "ok", "path": ".claude/insights/cognirepo-insights.html", "sections": ["overview", "timeline", "decisions", "challenges", "activity", "index-health"], "updated_at": "2026-08-21T12:00:00Z"}
+```
+
+---
+
 ## get_user_profile
 
 **Signature:** `get_user_profile(repo_path: str = None) → dict`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -224,7 +224,7 @@ from Repo B if both are linked to the same local organization.
 
 ## MCP Server
 
-CogniRepo exposes 34 MCP tools over stdio transport (see [docs/MCP_TOOLS.md](MCP_TOOLS.md) for the full reference):
+CogniRepo exposes 35 MCP tools over stdio transport (see [docs/MCP_TOOLS.md](MCP_TOOLS.md) for the full reference):
 
 | Tool | Parameters | Returns |
 |---|---|---|

--- a/glama.json
+++ b/glama.json
@@ -221,6 +221,24 @@
       }
     },
     {
+      "name": "generate_insights",
+      "description": "Generate/update the repo insights HTML report \u2014 a human-readable \"what happened in this repo\" summary (timeline, decisions, challenges, branch/ commit activity, index health), sourced only from real stored records.",
+      "inputSchema": {
+        "properties": {
+          "since": {
+            "default": "90d",
+            "type": "string"
+          },
+          "repo_path": {
+            "default": null,
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": []
+      }
+    },
+    {
       "name": "get_agent_bootstrap",
       "description": "Single-call session bootstrap for AI agents. Replaces the 4-call sequence (get_session_brief \u2192 get_last_context \u2192 get_user_profile \u2192 get_error_patterns) with one ~300-token payload.",
       "inputSchema": {

--- a/intelligence/retrieval/docs_search.py
+++ b/intelligence/retrieval/docs_search.py
@@ -28,7 +28,12 @@ from core.config.paths import get_path
 
 def _ast_index_file() -> str:
     return get_path("index/ast_index.json")
-_SKIP_DIRS = {".git", "venv", ".venv", "__pycache__", "node_modules", ".cognirepo"}
+_SKIP_DIRS = {".git", "venv", ".venv", "__pycache__", "node_modules"}
+# .cognirepo is internal storage (FAISS/graph/index state) and stays out of doc
+# search, EXCEPT .cognirepo/docs/ — generated markdown twins (COGNIREPO-303)
+# that must be dogfoodable via search_docs.
+_COGNIREPO_DIR = ".cognirepo"
+_COGNIREPO_ALLOWED_SUBDIR = "docs"
 # Filename substrings to skip — prevents test harness / CogniRepo internals from
 # polluting search results (e.g. MANUAL_TEST_SUITE.md matching every test prompt).
 _SKIP_FILE_SUBSTRINGS = {
@@ -182,6 +187,9 @@ def search_docs(query: str) -> list[dict]:
     # ── pass 2: full recursive walk — covers the whole repo tree ──────────────
     for root, dirnames, files in os.walk("."):
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        if os.path.basename(root) == _COGNIREPO_DIR:
+            dirnames[:] = [d for d in dirnames if d == _COGNIREPO_ALLOWED_SUBDIR]
+            continue
         for fname in files:
             if not fname.endswith(".md"):
                 continue

--- a/interface/adapters/cursor_mcp_config.json
+++ b/interface/adapters/cursor_mcp_config.json
@@ -20,6 +20,7 @@
     "episodic_search",
     "explain_change",
     "find_symbol_path",
+    "generate_insights",
     "get_agent_bootstrap",
     "get_error_patterns",
     "get_last_context",

--- a/interface/adapters/openai_tools.json
+++ b/interface/adapters/openai_tools.json
@@ -240,6 +240,27 @@
   {
     "type": "function",
     "function": {
+      "name": "generate_insights",
+      "description": "Generate/update the repo insights HTML report \u2014 a human-readable \"what happened in this repo\" summary (timeline, decisions, challenges, branch/ commit activity, index health), sourced only from real stored records.",
+      "parameters": {
+        "properties": {
+          "since": {
+            "default": "90d",
+            "type": "string"
+          },
+          "repo_path": {
+            "default": null,
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": []
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
       "name": "get_agent_bootstrap",
       "description": "Single-call session bootstrap for AI agents. Replaces the 4-call sequence (get_session_brief \u2192 get_last_context \u2192 get_user_profile \u2192 get_error_patterns) with one ~300-token payload.",
       "parameters": {

--- a/interface/cli/main.py
+++ b/interface/cli/main.py
@@ -1844,6 +1844,22 @@ def _cmd_ask_local(query: str, verbose: bool = False, top_k: int = 5) -> None:
     )
 
 
+def _cmd_insights(since: str = "90d") -> None:
+    """Generate/update the repo insights HTML report — thin wrapper over
+    insights_collector.collect() + interface.tools.insights.generate()."""
+    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from intelligence.orchestrator.insights_collector import collect  # pylint: disable=import-outside-toplevel
+    from interface.tools import insights as _insights_tool  # pylint: disable=import-outside-toplevel
+
+    repo_root = os.getcwd()
+    model = collect(repo_root, since=since)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    result = _insights_tool.generate(model, repo_root, now)
+    print(f"Insights report written: {result['path']}")
+    print(f"  sections: {', '.join(result['sections'])}")
+    print(f"  updated: {result['updated_at']}")
+
+
 def _cmd_prime(as_json: bool = False) -> None:
     """Generate a session brief for agent bootstrap — thin wrapper over prime_session()."""
     from interface.tools.prime_session import prime_session  # pylint: disable=import-outside-toplevel
@@ -3518,6 +3534,10 @@ def _main():
         help="Output raw JSON instead of human-readable brief.",
     )
 
+    # insights — repo-history HTML report (COGNIREPO-300)
+    p_insights = sub.add_parser("insights", help="Generate/update the repo insights HTML report")
+    p_insights.add_argument("--since", default="90d", help="History window, e.g. 90d (default: 90d)")
+
     # status — show live signal weights and cold-start progress (P1-A)
     sub.add_parser("status", help="Show live retrieval signal weights and index health")
 
@@ -4145,6 +4165,10 @@ def _main():
 
     if args.command == "prime":
         _cmd_prime(as_json=getattr(args, "json", False))
+        return
+
+    if args.command == "insights":
+        _cmd_insights(since=getattr(args, "since", "90d"))
         return
 
     if args.command == "status":

--- a/interface/server/manifest.json
+++ b/interface/server/manifest.json
@@ -218,6 +218,24 @@
       }
     },
     {
+      "name": "generate_insights",
+      "description": "Generate/update the repo insights HTML report \u2014 a human-readable \"what happened in this repo\" summary (timeline, decisions, challenges, branch/ commit activity, index health), sourced only from real stored records.",
+      "parameters": {
+        "properties": {
+          "since": {
+            "default": "90d",
+            "type": "string"
+          },
+          "repo_path": {
+            "default": null,
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "required": []
+      }
+    },
+    {
       "name": "get_agent_bootstrap",
       "description": "Single-call session bootstrap for AI agents. Replaces the 4-call sequence (get_session_brief \u2192 get_last_context \u2192 get_user_profile \u2192 get_error_patterns) with one ~300-token payload.",
       "parameters": {

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -2064,6 +2064,38 @@ def get_session_brief(repo_path: str | None = None) -> dict:
 
 
 @mcp.tool()
+def generate_insights(since: str = "90d", repo_path: str | None = None) -> dict:
+    """
+    Generate/update the repo insights HTML report — a human-readable "what
+    happened in this repo" summary (timeline, decisions, challenges, branch/
+    commit activity, index health), sourced only from real stored records.
+
+    Returns a small pointer, NOT the report content: {status, path, sections,
+    updated_at}. Claude: surface the path/link in your reply — do not quote
+    or reconstruct the report body from this tool's output.
+
+    since: history window, e.g. "90d" (default).
+    repo_path: optional absolute path to the target repository.
+    """
+    from datetime import datetime, timezone  # pylint: disable=import-outside-toplevel
+    from intelligence.orchestrator.insights_collector import collect  # pylint: disable=import-outside-toplevel
+    from interface.tools import insights as _insights_tool  # pylint: disable=import-outside-toplevel
+
+    target = os.path.abspath(repo_path) if repo_path else os.getcwd()
+    model = collect(target, since=since)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    result = _insights_tool.generate(model, target, now)
+    with _repo_ctx(repo_path):
+        log_event("insights generated", {"path": result["path"], "sections": result["sections"]})
+    return {
+        "status": "ok",
+        "path": result["path"],
+        "sections": result["sections"],
+        "updated_at": result["updated_at"],
+    }
+
+
+@mcp.tool()
 def get_user_profile(repo_path: str | None = None) -> dict:
     """
     Return the user's interaction style profile for Claude to adapt its responses.
@@ -2260,7 +2292,7 @@ _REGISTERED_TOOLS: set[str] = {
     "cross_repo_traverse", "episodic_search", "org_wide_search", "list_org_context",
     "get_user_profile", "record_error", "get_error_patterns", "link_repos",
     "record_user_preference", "supersede_learning", "get_agent_bootstrap",
-    "find_symbol_path", "get_service_endpoints",
+    "find_symbol_path", "get_service_endpoints", "generate_insights",
 }
 
 

--- a/tests/test_insights_cli_mcp.py
+++ b/tests/test_insights_cli_mcp.py
@@ -1,0 +1,107 @@
+# pylint: disable=missing-docstring, protected-access, redefined-outer-name
+# SPDX-FileCopyrightText: 2026 Ashlesha T
+# SPDX-License-Identifier: MIT
+#
+# This file is part of CogniRepo — https://github.com/ashlesh-t/cognirepo
+# Licensed under MIT. See LICENSE file in repository root.
+
+"""
+tests/test_insights_cli_mcp.py — COGNIREPO-303 acceptance criteria.
+
+AC1: `cognirepo insights` CLI exits 0 and prints the report path;
+     `generate_insights` MCP tool payload is < 120 output tokens (tiktoken).
+AC4: search_docs() finds the markdown twin under .cognirepo/docs/ post-generation,
+     while other .cognirepo/ internals (e.g. index/) stay excluded from doc search.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _run(*args, cwd, timeout=30):
+    return subprocess.run(
+        [sys.executable, "-m", "interface.cli.main"] + list(args),
+        cwd=cwd, capture_output=True, text=True, timeout=timeout,
+    )
+
+
+@pytest.fixture
+def isolated_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    monkeypatch.setenv("COGNIREPO_GLOBAL_DIR", str(tmp_path / "global"))
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=False)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=repo, capture_output=True, check=False)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, capture_output=True, check=False)
+    (repo / "README.md").write_text("# myrepo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=False)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, check=False)
+    init_res = _run("init", cwd=str(repo))
+    assert init_res.returncode == 0, init_res.stderr
+    return repo
+
+
+class TestCLIInsightsCommand:
+    def test_exit_zero_and_prints_path(self, isolated_repo):
+        res = _run("insights", cwd=str(isolated_repo))
+        assert res.returncode == 0, res.stderr
+        assert "insights report written" in res.stdout.lower()
+        assert str(isolated_repo) in res.stdout or ".claude" in res.stdout.lower()
+
+    def test_writes_html_under_claude_insights(self, isolated_repo):
+        _run("insights", cwd=str(isolated_repo))
+        out_dir = isolated_repo / ".claude" / "insights"
+        assert out_dir.is_dir()
+        htmls = list(out_dir.glob("*-insights.html"))
+        assert len(htmls) == 1
+
+
+class TestGenerateInsightsMCPTool:
+    def test_output_is_small_pointer_not_content(self, isolated_repo, monkeypatch):
+        monkeypatch.setenv("COGNIREPO_GLOBAL_DIR", str(isolated_repo.parent / "global"))
+        from interface.server.mcp_server import generate_insights
+
+        result = generate_insights(since="90d", repo_path=str(isolated_repo))
+        assert result["status"] == "ok"
+        assert result["path"].endswith("-insights.html")
+        assert isinstance(result["sections"], list) and result["sections"]
+        assert "updated_at" in result
+
+        try:
+            import tiktoken
+            enc = tiktoken.get_encoding("cl100k_base")
+            n_tokens = len(enc.encode(json.dumps(result)))
+        except ImportError:
+            n_tokens = len(json.dumps(result)) // 4  # rough fallback
+        assert n_tokens < 120
+
+
+class TestDocsSearchCarveOut:
+    def test_finds_cognirepo_docs_but_not_other_internals(self, isolated_repo):
+        cognirepo_dir = isolated_repo / ".cognirepo"
+        docs_dir = cognirepo_dir / "docs"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        (docs_dir / "myrepo-insights.md").write_text(
+            "# myrepo — Insights\n\nadopted zanzibar cache decision\n", encoding="utf-8"
+        )
+        index_dir = cognirepo_dir / "index"
+        index_dir.mkdir(exist_ok=True)
+        (index_dir / "secret_internal.md").write_text("zanzibar internal-only\n", encoding="utf-8")
+
+        old_cwd = os.getcwd()
+        os.chdir(isolated_repo)
+        try:
+            from intelligence.retrieval.docs_search import search_docs
+            results = search_docs("zanzibar")
+        finally:
+            os.chdir(old_cwd)
+
+        paths = [r["path"].replace("\\", "/") for r in results]
+        assert any("/.cognirepo/docs/myrepo-insights.md" in p or p.startswith(".cognirepo/docs/") for p in paths)
+        assert not any("/.cognirepo/index/" in p or p.startswith(".cognirepo/index/") for p in paths)

--- a/version.yml
+++ b/version.yml
@@ -23,4 +23,4 @@ mcp:
   title: "CogniRepo"
   transport: stdio
   runtime_hint: uvx
-  description: "FAISS, call graph, AST, BM25 — 34 MCP tools for AI agents. 50-80% token reduction. Offline."
+  description: "FAISS, call graph, AST, BM25 — 35 MCP tools for AI agents. 50-80% token reduction. Offline."


### PR DESCRIPTION
## Summary
- Wires COGNIREPO-301 (collector) + COGNIREPO-302 (renderer/writer) into the product: `cognirepo insights [--since 90d]` CLI command and `generate_insights(since, repo_path)` MCP tool, both calling the same collect→generate path.
- Fixes a retrieval gap found while implementing AC4: `intelligence/retrieval/docs_search.py` hard-skipped the entire `.cognirepo/` tree, which would have made the insights markdown twin (`.cognirepo/docs/<repo>-insights.md`) permanently unfindable via `search_docs`. Carved out `.cognirepo/docs/` specifically; all other `.cognirepo/` internals (index, graph, embeddings) remain excluded.
- **CLAUDE.md amendment (Exception 3)**: generated human-facing reports live under `.claude/insights/` per the approved wording in `docs/planning/02-insights-feature.md §Architecture-rule-compliance` — approved by the user before implementation. Added a routing-table row for `generate_insights`.
- Regenerated manifest.json / glama.json / openai_tools.json / cursor_mcp_config.json via `scripts/gen_tool_specs.py`; MCP tool payload measured at 105 tokens (AC5 requires < 120, via tiktoken).
- Doc updates: `docs/MCP_TOOLS.md`, `docs/CLI_REFERENCE.md` new entries; tool count 34 → 35 in README/USAGE/FEATURES/version.yml; FEATURES.md test-file count 98 → 99.

## Test plan
- [x] `pytest tests/test_insights_cli_mcp.py -v` — 4/4 pass (CLI exit 0 + path printed; MCP tool payload shape + token budget; docs_search carve-out finds the twin but not other `.cognirepo/` internals)
- [x] `pytest tests/ -q` (deselecting one pre-existing flaky xdist watcher test, verified flaky on `development` before this branch) — 1382 passed, 5 skipped
- [x] `pytest tests/test_manifest_drift.py -q` — 5/5 pass (no drift after regenerating artifacts)
- [x] `pylint interface/cli/main.py interface/server/mcp_server.py intelligence/retrieval/docs_search.py tests/test_insights_cli_mcp.py --disable=C,R,import-error --fail-under=8.0` — 9.81+/10
- [x] `bandit -r ... --severity-level high` — no issues
- [x] Manual live leg of TC-303-1/TC-303-2 (MCP client reconnect + Claude prompt) — recorded as pending in `JIRA/EPIC-RepoInsights-300/STORY/COGNIREPO-303/TEST/COGNIREPO-303-TEST_SUITE.md`; automated equivalents pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)