### PR TITLE
COGNIREPO-401: Mood signal derivation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,11 @@ Goal: cut token overhead and context loss between AI sessions, not add complexit
 ## Behavioral confirmation rule
 
 After `get_user_profile()`, apply `framing_hints` to every response (depth, vocabulary, code-focus).
+`get_user_profile()`/`get_agent_bootstrap()` also carry a `mood` signal ({state, evidence,
+suggested_adaptation}) derived from recent errors/queries/edits — neutral with empty evidence on
+sparse data. **Precedence: explicit user request > persona > framing_hints/mood.** A `mood` of
+"frustrated" means act on `suggested_adaptation` (e.g. verify against `get_error_patterns` before
+proposing fixes), not adopt a tone — it never overrides what the user actually asked for.
 **When ambiguity detected:** if the user's current request conflicts with their established pattern
 (e.g. they always ask for concise answers but this request seems to want a long walkthrough),
 ask ONE short clarifying question before proceeding. Do not assume — confirm.

--- a/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-401/COGNIREPO-401.md
+++ b/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-401/COGNIREPO-401.md
@@ -31,3 +31,12 @@ UserPromptSubmit hook text for contradictions with that rule.
 ## Risks / notes
 - Session boundary: derive within the current session window (last N minutes), not all-time
   counts — all-time errors would pin mood permanently.
+
+## Analyze correction (line drift vs Discovery, verified at implementation HEAD)
+Discovery §1 line numbers were cited against `146627d` (v2.0.0); functions moved but are
+unchanged in shape: `record_error` now :406, `get_error_patterns` :544, `record_query` :251,
+`record_query_rewrite`/`get_query_rewrites` :509-540, `record_file_edit` :362, `get_hot_symbols`
+:577-594, `get_user_profile` :437-484. `query_rewrites[].hit_count` is initialized to 0 in
+`record_query_rewrite` but nothing in the current codebase increments it despite the docstring
+claim ("incremented each time a matching query is seen") — pre-existing gap, out of scope for
+this story; derive_mood() reads whatever value is there.

--- a/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-401/TEST/COGNIREPO-401-TEST_SUITE.md
+++ b/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-401/TEST/COGNIREPO-401-TEST_SUITE.md
@@ -7,5 +7,12 @@
 - Prompt: "Check my profile — how am I doing this session, and what should you do differently?"
 - Expected results: mood.state=frustrated; evidence cites the ImportError streak;
   suggested_adaptation is actionable; on a fresh repo the same call reports neutral.
-- Obtained results:
-- Verdict:
+- Obtained results: ran the record_error/get_user_profile mechanics directly (not via a live
+  MCP session) on cognirepo_test_repo/medium/ansible: 3× `record_error("ImportError", ...)`
+  then `get_user_profile()["mood"]` → `{"state": "frustrated", "evidence": ["ImportError: 3
+  occurrences in the last 15m"], "suggested_adaptation": "verify against get_error_patterns
+  before proposing fixes"}`. Same call on a fresh dummy repo (no errors seeded) →
+  `{"state": "neutral", "evidence": [], "suggested_adaptation": ""}`. The live-agent leg (an
+  actual reconnected Claude session reading mood off get_user_profile through MCP and changing
+  its behavior accordingly) not re-run here — pending user's own session.
+- Verdict: PASS (mechanics); live-agent leg pending user confirmation

--- a/JIRA/EPIC-MoodPersonaLayer-400/status.yml
+++ b/JIRA/EPIC-MoodPersonaLayer-400/status.yml
@@ -1,8 +1,8 @@
 epic_id: COGNIREPO-400
-status: not-started
+status: in-progress
 stories:
   - id: COGNIREPO-401
-    status: not-started
+    status: in-progress
     branch: story/COGNIREPO-401
     pr: null
     test_status: not-run

--- a/JIRA/EPIC-MoodPersonaLayer-400/status.yml
+++ b/JIRA/EPIC-MoodPersonaLayer-400/status.yml
@@ -2,9 +2,9 @@ epic_id: COGNIREPO-400
 status: in-progress
 stories:
   - id: COGNIREPO-401
-    status: in-progress
+    status: in-review
     branch: story/COGNIREPO-401
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/57
     test_status: not-run
   - id: COGNIREPO-402
     status: not-started

--- a/JIRA/status.yml
+++ b/JIRA/status.yml
@@ -16,7 +16,7 @@ epics:
     blocked_by: []
   - id: COGNIREPO-400
     name: MoodPersonaLayer
-    status: not-started
+    status: in-progress
     blocked_by: []
   - id: COGNIREPO-500
     name: SubagentEnrichment

--- a/data/graph/behaviour_tracker.py
+++ b/data/graph/behaviour_tracker.py
@@ -47,6 +47,10 @@ def _behaviour_lock():
 
 
 _USEFUL_WINDOW = timedelta(minutes=5)
+_MOOD_FRUSTRATED_WINDOW = timedelta(minutes=15)
+_MOOD_FRUSTRATED_ERROR_THRESHOLD = 3
+_MOOD_FRUSTRATED_REWRITE_THRESHOLD = 2
+_MOOD_FLOW_WINDOW = timedelta(minutes=20)
 
 
 def _now() -> str:
@@ -489,7 +493,80 @@ class BehaviourTracker:
             "total_queries_tracked": len(self.data.get("query_history", {})),
             "explicit_preferences": self.get_preferences(),
             "query_rewrites": self.get_query_rewrites(),
+            "mood": self.derive_mood(),
         }
+
+    def derive_mood(self) -> dict:
+        """Derive a lightweight mood signal from existing behaviour data.
+
+        state: "frustrated" | "flow" | "neutral". Never a bare sentiment label —
+        suggested_adaptation is always an action Claude can take, not a tone
+        adjective (COGNIREPO-401 AC4). Sparse/fresh data degrades to neutral with
+        empty evidence, mirroring get_user_profile's "no profile yet" fallback.
+
+        Derived within a recent time window (not all-time counts) so mood tracks
+        the current session rather than pinning permanently on old errors.
+        """
+        now = datetime.now(tz=timezone.utc)
+
+        def _recent(ts: str | None, window: timedelta) -> bool:
+            if not ts:
+                return False
+            try:
+                parsed = datetime.fromisoformat(ts)
+            except ValueError:
+                return False
+            return now - parsed <= window
+
+        # ── frustrated: error streak or a rewrite correction still recurring ──
+        evidence: list[str] = []
+        for error_type, info in self.data.get("error_patterns", {}).items():
+            recent_occ = [
+                occ for occ in info.get("occurrences", [])
+                if _recent(occ.get("time"), _MOOD_FRUSTRATED_WINDOW)
+            ]
+            if len(recent_occ) >= _MOOD_FRUSTRATED_ERROR_THRESHOLD:
+                evidence.append(f"{error_type}: {len(recent_occ)} occurrences in the last 15m")
+        for rw in self.data.get("query_rewrites", []):
+            if rw.get("hit_count", 0) >= _MOOD_FRUSTRATED_REWRITE_THRESHOLD and _recent(
+                rw.get("updated_at") or rw.get("stored_at"), _MOOD_FRUSTRATED_WINDOW
+            ):
+                evidence.append(
+                    f"query rewrite '{rw.get('original', '')[:40]}' re-corrected "
+                    f"{rw.get('hit_count')}x"
+                )
+        if evidence:
+            return {
+                "state": "frustrated",
+                "evidence": evidence,
+                "suggested_adaptation": "verify against get_error_patterns before proposing fixes",
+            }
+
+        # ── flow: sustained queries + edits with zero new errors ─────────────
+        recent_queries = [
+            qh for qh in self.data.get("query_history", {}).values()
+            if _recent(qh.get("timestamp"), _MOOD_FLOW_WINDOW)
+        ]
+        recent_edits = any(
+            _recent(session.get("start"), _MOOD_FLOW_WINDOW) and session.get("files_touched")
+            for session in self.data.get("session_registry", {}).values()
+        )
+        recent_errors = any(
+            _recent(occ.get("time"), _MOOD_FLOW_WINDOW)
+            for info in self.data.get("error_patterns", {}).values()
+            for occ in info.get("occurrences", [])
+        )
+        if recent_queries and recent_edits and not recent_errors:
+            return {
+                "state": "flow",
+                "evidence": [
+                    f"{len(recent_queries)} queries and active edits over the last 20m "
+                    f"with 0 new errors"
+                ],
+                "suggested_adaptation": "batch confirmations; skip re-explaining settled context",
+            }
+
+        return {"state": "neutral", "evidence": [], "suggested_adaptation": ""}
 
     def record_user_preference(self, key: str, value: str) -> dict:
         """Store an explicit user preference (key/value pair) with timestamp.

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -546,7 +546,7 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
 
 **Signature:** `get_user_profile(repo_path: str = None) → dict`
 
-**When:** ALWAYS call at session start (step 3). Apply `framing_hints` to ALL responses. Shows depth preference, domain vocabulary, code-focus %, and explicit stored preferences.
+**When:** ALWAYS call at session start (step 3). Apply `framing_hints` to ALL responses. Shows depth preference, domain vocabulary, code-focus %, explicit stored preferences, and a `mood` signal.
 
 **Output:**
 ```json
@@ -555,9 +555,21 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
   "framing_hints": "prefers concise responses; focuses on code/symbols",
   "top_terminology": ["context_pack", "graph", "episodic"],
   "explicit_preferences": {"response_style": "concise"},
-  "total_queries_tracked": 47
+  "total_queries_tracked": 47,
+  "mood": {
+    "state": "neutral",
+    "evidence": [],
+    "suggested_adaptation": ""
+  }
 }
 ```
+
+**mood** (COGNIREPO-401): derived from recent (last 15-20m) error streaks, query
+velocity, and edit momentum already in the behaviour store — `state` is
+`neutral`/`frustrated`/`flow`, never a bare sentiment label; `suggested_adaptation`
+is always an action (e.g. "verify against get_error_patterns before proposing
+fixes"), not a tone adjective. Neutral with empty evidence on sparse/fresh data.
+Precedence: explicit user request > persona > `framing_hints`/`mood`.
 
 ---
 
@@ -626,6 +638,7 @@ Search memories across ALL repositories in the organization. Prefer `cross_repo_
   "hot_symbols": ["hybrid_retrieve:retrieval/hybrid.py:45", "context_pack:tools/context_pack.py:12"],
   "last_focus": {"files": ["retrieval/hybrid.py"], "query": "how does scoring work", "agent": "claude"},
   "framing": {"depth": "detailed", "vocabulary": ["retrieval", "faiss", "hybrid"], "hints": "prefers detailed responses; often asks 'how' questions; domain vocabulary: retrieval, faiss, hybrid"},
+  "mood": {"state": "neutral", "evidence": [], "suggested_adaptation": ""},
   "error_patterns": [{"type": "OOM", "count": 2, "prevention_hint": "Check RSS before loading large index"}],
   "index_health": {"symbols": 1240, "files": 92, "status": "ok"},
   "recent_timeline": [
@@ -644,8 +657,8 @@ quick "what happened recently" view. Folded into this tool's existing output rat
 than a new MCP tool (0 manifest tokens vs. ~180 measured for a standalone
 `get_timeline` tool). For the full query surface (`since`/`include_archived`/`limit`,
 plus the deterministic `rollup()` — counts + top decisions/errors, no model-generated
-text), call `data.memory.timeline.merge()`/`rollup()` directly, or from a future
-`generate_insights` tool (EPIC-300).
+text), call `data.memory.timeline.merge()`/`rollup()` directly, or use the
+`generate_insights` tool (COGNIREPO-303).
 
 **decision_nudge** (COGNIREPO-205): present only when the last 30 days have ≥5
 episodes but 0 decisions — a hint to use `record_decision` for architectural

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -1831,6 +1831,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
       hot_symbols   — ["fn:file:line", ...] top 8 symbols by behaviour weight
       last_focus    — {files, query, agent} from last agent's context_pack
       framing       — {depth, vocabulary} from user profile (empty if tracking off)
+      mood          — {state, evidence, suggested_adaptation}; neutral/empty on sparse data
       error_patterns — top 3 recurring errors with prevention hints
       index_health  — {symbols, files, status}
       recent_timeline — last 5 entries (past 7 days) merged across sessions,
@@ -1899,6 +1900,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         hot_symbols: list[str] = []
         framing: dict = {}
         error_patterns: list = []
+        mood: dict = {"state": "neutral", "evidence": [], "suggested_adaptation": ""}
         if _behaviour_enabled():
             try:
                 from data.graph.behaviour_tracker import BehaviourTracker  # pylint: disable=import-outside-toplevel
@@ -1914,6 +1916,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
                     "hints": profile.get("framing_hints", ""),
                 }
                 error_patterns = bt.get_error_patterns(min_count=1)[:3]
+                mood = profile.get("mood", mood)
             except Exception:  # pylint: disable=broad-except
                 pass
 
@@ -1992,6 +1995,7 @@ def get_agent_bootstrap(repo_path: str | None = None) -> dict:
         "hot_symbols": hot_symbols,
         "last_focus": last_focus,
         "framing": framing,
+        "mood": mood,
         "error_patterns": error_patterns,
         "index_health": {"symbols": symbol_count, "files": file_count, "status": index_status},
         "recent_timeline": recent_timeline,
@@ -2101,7 +2105,9 @@ def get_user_profile(repo_path: str | None = None) -> dict:
     Return the user's interaction style profile for Claude to adapt its responses.
 
     Includes: depth preference, dominant question types, domain vocabulary,
-    code-focus percentage, and framing hints Claude should apply.
+    code-focus percentage, framing hints, and a mood signal ({state, evidence,
+    suggested_adaptation} — neutral/empty on sparse data) Claude should apply.
+    Precedence: explicit user request > persona > framing_hints/mood.
 
     Call this at the start of a session to calibrate response style.
 

--- a/tests/test_behaviour_tracker.py
+++ b/tests/test_behaviour_tracker.py
@@ -119,6 +119,82 @@ class TestBehaviourTrackerCore:
         assert prefs["format"] == "markdown"
 
 
+# ── Mood derivation (COGNIREPO-401) ──────────────────────────────────────────
+
+class TestMoodDerivation:
+    def test_empty_store_is_neutral_with_no_evidence(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        mood = bt.derive_mood()
+        assert mood == {"state": "neutral", "evidence": [], "suggested_adaptation": ""}
+
+    def test_three_same_type_errors_within_15min_is_frustrated(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        bt.record_error("ImportError", file_path="utils.py", message="cannot import X")
+        bt.record_error("ImportError", file_path="utils.py", message="cannot import X")
+        bt.record_error("ImportError", file_path="utils.py", message="cannot import X")
+        mood = bt.derive_mood()
+        assert mood["state"] == "frustrated"
+        assert any("ImportError" in e for e in mood["evidence"])
+
+    def test_suggested_adaptation_is_an_action_not_a_tone_word(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        for _ in range(3):
+            bt.record_error("TypeError", file_path="main.py")
+        mood = bt.derive_mood()
+        adaptation = mood["suggested_adaptation"].lower()
+        assert "get_error_patterns" in adaptation
+        for tone_word in ("frustrated", "annoyed", "happy", "calm"):
+            assert tone_word not in adaptation
+
+    def test_old_errors_outside_window_do_not_pin_frustrated(self, tmp_path, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        bt = _make_bt(tmp_path, monkeypatch)
+        bt.record_error("ImportError", file_path="utils.py")
+        bt.record_error("ImportError", file_path="utils.py")
+        bt.record_error("ImportError", file_path="utils.py")
+        stale = (datetime.now(tz=timezone.utc) - timedelta(hours=2)).isoformat()
+        for occ in bt.data["error_patterns"]["ImportError"]["occurrences"]:
+            occ["time"] = stale
+        mood = bt.derive_mood()
+        assert mood["state"] == "neutral"
+        assert mood["evidence"] == []
+
+    def test_sustained_edits_and_queries_with_no_errors_is_flow(self, tmp_path, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        bt = _make_bt(tmp_path, monkeypatch)
+        bt.record_query("q1", "how does routing work", [])
+        recent = (datetime.now(tz=timezone.utc) - timedelta(minutes=15)).isoformat()
+        bt.data["query_history"]["q1"]["timestamp"] = recent
+        bt.data["session_registry"]["s1"] = {
+            "start": recent, "queries": [], "files_touched": ["routing.py"],
+        }
+        mood = bt.derive_mood()
+        assert mood["state"] == "flow"
+        assert mood["evidence"]
+
+    def test_get_user_profile_includes_mood_key(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        profile = bt.get_user_profile()
+        assert "mood" in profile
+        assert profile["mood"]["state"] == "neutral"
+
+    def test_get_user_profile_other_fields_unchanged_when_mood_neutral(self, tmp_path, monkeypatch):
+        """Golden test (AC3): adding `mood` must not perturb any other profile field."""
+        bt = _make_bt(tmp_path, monkeypatch)
+        bt.record_query("q1", "how does auth work", [])
+        profile = bt.get_user_profile()
+        mood = profile.pop("mood")
+        assert mood["state"] == "neutral"
+        expected = {
+            "depth_preference", "top_question_type", "question_type_distribution",
+            "top_terminology", "code_focus_percent", "framing_hints", "sample_queries",
+            "total_queries_tracked", "explicit_preferences", "query_rewrites",
+        }
+        assert set(profile.keys()) == expected
+
+
 # ── Framing hints lifecycle (T3.1 fix) ───────────────────────────────────────
 
 class TestFramingHintsLifecycle:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -322,6 +322,51 @@ class TestAgentBootstrapFraming:
         assert result["framing"]["hints"] == "prefers code-first answers"
         assert "auth" in result["framing"]["vocabulary"]
 
+    def test_agent_bootstrap_mood_populated(self, tmp_path, monkeypatch):
+        """mood must surface from the profile when behaviour data is present."""
+        from unittest.mock import patch, MagicMock
+        monkeypatch.setenv("COGNIREPO_DIR", str(tmp_path / ".cognirepo"))
+        (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
+
+        fake_profile = {
+            "depth_preference": "detailed",
+            "top_terminology": [],
+            "framing_hints": "",
+            "explicit_preferences": {},
+            "mood": {
+                "state": "frustrated",
+                "evidence": ["ImportError: 3 occurrences in the last 15m"],
+                "suggested_adaptation": "verify against get_error_patterns before proposing fixes",
+            },
+        }
+        fake_bt = MagicMock()
+        fake_bt.data = {"symbol_weights": {}}
+        fake_bt.get_user_profile.return_value = fake_profile
+        fake_bt.get_error_patterns.return_value = []
+
+        with patch("interface.server.mcp_server._behaviour_enabled", return_value=True), \
+             patch("interface.server.mcp_server._get_graph", return_value=MagicMock()), \
+             patch("data.graph.behaviour_tracker.BehaviourTracker", return_value=fake_bt), \
+             patch("interface.server.mcp_server._index_is_stale", return_value=False):
+            from interface.server.mcp_server import get_agent_bootstrap
+            result = get_agent_bootstrap()
+
+        assert result["mood"]["state"] == "frustrated"
+        assert result["mood"]["evidence"]
+
+    def test_agent_bootstrap_mood_defaults_neutral_when_disabled(self, tmp_path, monkeypatch):
+        """mood must default to neutral/empty when behaviour tracking is disabled."""
+        from unittest.mock import patch
+        monkeypatch.setenv("COGNIREPO_DIR", str(tmp_path / ".cognirepo"))
+        (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
+
+        with patch("interface.server.mcp_server._behaviour_enabled", return_value=False), \
+             patch("interface.server.mcp_server._index_is_stale", return_value=False):
+            from interface.server.mcp_server import get_agent_bootstrap
+            result = get_agent_bootstrap()
+
+        assert result["mood"] == {"state": "neutral", "evidence": [], "suggested_adaptation": ""}
+
     def test_agent_bootstrap_framing_empty_when_disabled(self, tmp_path, monkeypatch):
         """framing must be empty dict when behaviour tracking is disabled."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- `BehaviourTracker.derive_mood()` -> `{state, evidence, suggested_adaptation}` sourced entirely from existing behaviour data (error streaks, query velocity, edit momentum) — no new subsystem.
- Additive `mood` key in `get_user_profile()` and `get_agent_bootstrap()` outputs; input schemas unchanged, manifest tokens unchanged (3499 -> 3499, measured).
- CLAUDE.md precedence rule added: explicit user request > persona > framing_hints/mood.

## Acceptance criteria
- [x] 3 same-type errors within 15m -> `frustrated` with the streak in evidence
- [x] Empty store -> `neutral`, empty evidence
- [x] Profile/bootstrap otherwise unchanged (golden test asserts exact other-field set)
- [x] `suggested_adaptation` is always an action, never a bare tone word

## Test plan
- [x] Full pytest suite: 1392 passed, 5 skipped (was 1383/5 pre-story)
- [x] `JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-401/TEST/COGNIREPO-401-TEST_SUITE.md` — mechanics leg PASS (dogfooded on cognirepo_test_repo/medium/ansible + dummy); live-agent leg pending user's own session

🤖 Generated with [Claude Code](https://claude.com/claude-code)