### PR TITLE
COGNIREPO-402: Persona registry (mentor / pair / caveman)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,17 @@ ask ONE short clarifying question before proceeding. Do not assume — confirm.
 **After every session:** call `record_decision()` for architectural choices, `log_episode()` for
 milestones, `record_error()` for any errors hit. This updates the profile for next session.
 
+## Personas (COGNIREPO-402)
+
+Opt-in only — **never enable a persona unless the user explicitly asks.** Set via
+`record_user_preference("persona", "<name>")`; read from `get_user_profile()['active_persona']` /
+`['persona_behavior']` — absent entirely when unset (no behavior change from pre-402 baseline).
+Exactly three, each a concrete behavior delta, never a decorative label:
+- **mentor** — retrieval depth +1 (include episodic context by default), full explanations, link
+  responses to related past decisions/history.
+- **pair** — the default-equivalent: current behavior plus mood-aware phrasing only.
+- **caveman** — economy/telegraphic output (full spec: COGNIREPO-403).
+
 ## Tool routing (for Claude Code agents using this repo)
 
 | Task | Use this first |

--- a/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-402/TEST/COGNIREPO-402-TEST_SUITE.md
+++ b/JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-402/TEST/COGNIREPO-402-TEST_SUITE.md
@@ -7,5 +7,12 @@
 - Prompt: "Set my persona to mentor, then explain how retrieval caching works here."
 - Expected results: mentor answer visibly deeper (episodic context included); invalid value
   rejected with the valid list; cleared ⇒ baseline behavior.
-- Obtained results:
-- Verdict:
+- Obtained results: ran the record_user_preference/get_user_profile mechanics directly (not via a
+  live MCP session): `record_user_preference("persona","mentor")` → `{"recorded": true}`,
+  `get_user_profile()["active_persona"]=="mentor"` with the full behavior block surfaced.
+  `record_user_preference("persona","banana")` → `{"recorded": false, "error": "unknown persona
+  'banana' — valid: ['caveman', 'mentor', 'pair']"}`, and `active_persona` stayed `"mentor"`
+  (invalid value did not clobber the existing one). Switching to `"pair"` afterward correctly
+  updated `active_persona`. The live-agent leg (an actual reconnected Claude session visibly
+  answering deeper under mentor vs. baseline) not re-run here — pending user's own session.
+- Verdict: PASS (mechanics); live-agent leg pending user confirmation

--- a/JIRA/EPIC-MoodPersonaLayer-400/status.yml
+++ b/JIRA/EPIC-MoodPersonaLayer-400/status.yml
@@ -7,9 +7,9 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/57
     test_status: pass
   - id: COGNIREPO-402
-    status: in-progress
+    status: in-review
     branch: story/COGNIREPO-402
-    pr: null
+    pr: https://github.com/ashlesh-t/cognirepo/pull/58
     test_status: not-run
   - id: COGNIREPO-403
     status: not-started

--- a/JIRA/EPIC-MoodPersonaLayer-400/status.yml
+++ b/JIRA/EPIC-MoodPersonaLayer-400/status.yml
@@ -7,7 +7,7 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/57
     test_status: pass
   - id: COGNIREPO-402
-    status: not-started
+    status: in-progress
     branch: story/COGNIREPO-402
     pr: null
     test_status: not-run

--- a/data/graph/behaviour_tracker.py
+++ b/data/graph/behaviour_tracker.py
@@ -52,6 +52,26 @@ _MOOD_FRUSTRATED_ERROR_THRESHOLD = 3
 _MOOD_FRUSTRATED_REWRITE_THRESHOLD = 2
 _MOOD_FLOW_WINDOW = timedelta(minutes=20)
 
+# Reserved "persona" preference values (COGNIREPO-402) — opt-in only, never auto-enabled.
+# Each behavior delta must be concrete (retrieval depth / verbosity / tone), never decorative.
+_PERSONAS: dict[str, dict[str, str]] = {
+    "mentor": {
+        "retrieval_depth": "+1 — include episodic context by default",
+        "verbosity": "full explanations",
+        "tone": "links responses to related past decisions/history",
+    },
+    "pair": {
+        "retrieval_depth": "default",
+        "verbosity": "default, plus mood-aware phrasing",
+        "tone": "current default-equivalent behavior",
+    },
+    "caveman": {
+        "retrieval_depth": "default",
+        "verbosity": "economy output — see COGNIREPO-403 for the full spec",
+        "tone": "telegraphic, complete-information style; opt-in only, never auto-enabled",
+    },
+}
+
 
 def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
@@ -481,8 +501,9 @@ class BehaviourTracker:
         )
 
         sample_queries = patterns[-3:] if patterns else []
+        explicit_preferences = self.get_preferences()
 
-        return {
+        profile = {
             "depth_preference": depth,
             "top_question_type": top_qtype,
             "question_type_distribution": qtypes,
@@ -491,10 +512,18 @@ class BehaviourTracker:
             "framing_hints": framing_hints,
             "sample_queries": sample_queries,
             "total_queries_tracked": len(self.data.get("query_history", {})),
-            "explicit_preferences": self.get_preferences(),
+            "explicit_preferences": explicit_preferences,
             "query_rewrites": self.get_query_rewrites(),
             "mood": self.derive_mood(),
         }
+        # Additive only — no persona set (or an already-rejected/unknown value that somehow
+        # made it into storage before this validation existed) leaves the payload identical
+        # to pre-402 output (COGNIREPO-402 AC2).
+        active_persona = explicit_preferences.get("persona")
+        if active_persona in _PERSONAS:
+            profile["active_persona"] = active_persona
+            profile["persona_behavior"] = _PERSONAS[active_persona]
+        return profile
 
     def derive_mood(self) -> dict:
         """Derive a lightweight mood signal from existing behaviour data.
@@ -572,7 +601,14 @@ class BehaviourTracker:
         """Store an explicit user preference (key/value pair) with timestamp.
 
         Persisted immediately. Surfaced by get_user_profile()['explicit_preferences'].
+        The reserved "persona" key is validated against _PERSONAS — an unknown value is
+        rejected (not stored) so a typo doesn't silently no-op the opt-in.
         """
+        if key == "persona" and value not in _PERSONAS:
+            return {
+                "key": key, "value": value, "recorded": False,
+                "error": f"unknown persona '{value}' — valid: {sorted(_PERSONAS)}",
+            }
         prefs = self.data.setdefault("user_preferences", {})
         prefs[key] = {"value": value, "updated_at": _now()}
         self.save()

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -571,6 +571,20 @@ is always an action (e.g. "verify against get_error_patterns before proposing
 fixes"), not a tone adjective. Neutral with empty evidence on sparse/fresh data.
 Precedence: explicit user request > persona > `framing_hints`/`mood`.
 
+**active_persona / persona_behavior** (COGNIREPO-402): present ONLY when the user has
+opted into a persona via `record_user_preference("persona", "mentor"|"pair"|"caveman")`
+— absent entirely otherwise (zero payload change from pre-402 baseline). Example when set:
+```json
+{
+  "active_persona": "mentor",
+  "persona_behavior": {
+    "retrieval_depth": "+1 — include episodic context by default",
+    "verbosity": "full explanations",
+    "tone": "links responses to related past decisions/history"
+  }
+}
+```
+
 ---
 
 ## get_error_patterns
@@ -616,6 +630,13 @@ Precedence: explicit user request > persona > `framing_hints`/`mood`.
 **Output:**
 ```json
 {"key": "response_style", "value": "concise", "recorded": true}
+```
+
+**Reserved key `"persona"`** (COGNIREPO-402): opt-in only, never enable without an explicit
+ask. Valid values: `mentor` / `pair` / `caveman` (see [Personas](USAGE.md#personas) for the
+behavior deltas). An unknown value is rejected, not stored:
+```json
+{"key": "persona", "value": "wizard", "recorded": false, "error": "unknown persona 'wizard' — valid: ['caveman', 'mentor', 'pair']"}
 ```
 
 ---

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -17,6 +17,7 @@ Complete documentation for every command, MCP tool, and configuration option.
 9. [VS Code MCP Setup](#vs-code-mcp-setup)
 10. [GitHub Copilot Integration](#github-copilot-integration)
 11. [Adding API Keys](#adding-api-keys)
+12. [Personas](#personas)
 
 ---
 
@@ -498,3 +499,31 @@ After 2+ queries, `get_user_profile()` returns a `framing_hints` string. The `Us
 hook prints this as a system-reminder before each Claude response — no MCP call required.
 `sync_claude_memory.py` ensures any notes you save via Claude Code's memory system are
 immediately searchable via `retrieve_memory()`.
+
+---
+
+## Personas
+
+Opt-in only (COGNIREPO-402) — a persona is never enabled automatically, only by an explicit
+request. Set it with the existing preference tool — no new tool, no schema change:
+
+```
+record_user_preference("persona", "mentor")   # or "pair" / "caveman"
+```
+
+`get_user_profile()` then additionally returns `active_persona` and `persona_behavior`; both
+keys are absent entirely when no persona is set (zero behavior change from the pre-402 baseline).
+An unknown persona name is rejected outright — `{"recorded": false, "error": "unknown persona
+'...' — valid: ['caveman', 'mentor', 'pair']"}` — nothing silently no-ops.
+
+Exactly three personas, each a concrete behavior delta — never a decorative tone label:
+
+| Persona | Retrieval depth | Verbosity | Tone |
+|---|---|---|---|
+| `mentor` | +1 — includes episodic context by default | Full explanations | Links responses to related past decisions/history |
+| `pair` | Default | Default, plus mood-aware phrasing | Current default-equivalent behavior |
+| `caveman` | Default | Economy/telegraphic output (full spec: COGNIREPO-403) | Complete-information, no filler — opt-in only, never auto-enabled |
+
+Precedence, same as `framing_hints`/`mood`: **explicit user request > persona >
+framing_hints/mood.** A persona shapes *how* Claude answers; it never overrides *what* the user
+actually asked for.

--- a/interface/server/mcp_server.py
+++ b/interface/server/mcp_server.py
@@ -2108,6 +2108,9 @@ def get_user_profile(repo_path: str | None = None) -> dict:
     code-focus percentage, framing hints, and a mood signal ({state, evidence,
     suggested_adaptation} — neutral/empty on sparse data) Claude should apply.
     Precedence: explicit user request > persona > framing_hints/mood.
+    If the user has opted into a persona (COGNIREPO-402, via record_user_preference),
+    the payload additionally carries active_persona + persona_behavior — absent
+    entirely when no persona is set (byte-identical to pre-402 output otherwise).
 
     Call this at the start of a session to calibrate response style.
 
@@ -2143,6 +2146,15 @@ def record_user_preference(
       record_user_preference("query_rewrite", "deploy model", context="user means: update the ML model weights in production, not software deploy")
     Stored in query_rewrites list; agents apply these before retrieval so future
     similar queries hit the right code even when phrasing is off.
+
+    **Persona selection** (preference_key = "persona", COGNIREPO-402):
+    Opt-in only — never enable a persona without the user explicitly asking.
+    Valid values: "mentor" (deeper retrieval + full explanations + links to history),
+    "pair" (default-equivalent, mood-aware phrasing), "caveman" (economy/telegraphic
+    output, see COGNIREPO-403). An unknown value is rejected, not stored — response
+    includes {"recorded": false, "error": "..."}. Surfaced via
+    get_user_profile()['active_persona'] / ['persona_behavior']. Precedence: explicit
+    user request > persona > framing_hints/mood (see CLAUDE.md).
 
     Claude: call this when:
     - User corrects your interpretation ("no, I meant X not Y")

--- a/tests/test_behaviour_tracker.py
+++ b/tests/test_behaviour_tracker.py
@@ -195,6 +195,56 @@ class TestMoodDerivation:
         assert set(profile.keys()) == expected
 
 
+# ── Persona registry (COGNIREPO-402) ─────────────────────────────────────────
+
+class TestPersonaRegistry:
+    def test_valid_persona_recorded_and_surfaced(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        result = bt.record_user_preference("persona", "mentor")
+        assert result["recorded"] is True
+        profile = bt.get_user_profile()
+        assert profile["active_persona"] == "mentor"
+        assert profile["persona_behavior"]["retrieval_depth"] == "+1 — include episodic context by default"
+
+    def test_unknown_persona_rejected_not_stored(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        result = bt.record_user_preference("persona", "wizard")
+        assert result["recorded"] is False
+        assert "mentor" in result["error"] and "pair" in result["error"] and "caveman" in result["error"]
+        assert "persona" not in bt.get_preferences()
+
+    def test_no_persona_set_omits_keys_entirely(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        profile = bt.get_user_profile()
+        assert "active_persona" not in profile
+        assert "persona_behavior" not in profile
+
+    def test_no_persona_golden_regression_on_other_fields(self, tmp_path, monkeypatch):
+        """AC2: no persona set ⇒ profile identical to pre-402 field set."""
+        bt = _make_bt(tmp_path, monkeypatch)
+        bt.record_query("q1", "how does auth work", [])
+        profile = bt.get_user_profile()
+        expected = {
+            "depth_preference", "top_question_type", "question_type_distribution",
+            "top_terminology", "code_focus_percent", "framing_hints", "sample_queries",
+            "total_queries_tracked", "explicit_preferences", "query_rewrites", "mood",
+        }
+        assert set(profile.keys()) == expected
+
+    def test_all_three_personas_have_concrete_behavior_blocks(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        for name in ("mentor", "pair", "caveman"):
+            bt.record_user_preference("persona", name)
+            behavior = bt.get_user_profile()["persona_behavior"]
+            assert set(behavior.keys()) == {"retrieval_depth", "verbosity", "tone"}
+            assert all(isinstance(v, str) and v for v in behavior.values())
+
+    def test_other_preference_keys_unaffected_by_persona_validation(self, tmp_path, monkeypatch):
+        bt = _make_bt(tmp_path, monkeypatch)
+        result = bt.record_user_preference("response_style", "code first")
+        assert result["recorded"] is True
+
+
 # ── Framing hints lifecycle (T3.1 fix) ───────────────────────────────────────
 
 class TestFramingHintsLifecycle:

--- a/tests/test_mcp_tools_extended.py
+++ b/tests/test_mcp_tools_extended.py
@@ -166,6 +166,15 @@ def test_record_user_preference_returns_dict():
     assert isinstance(result, dict) or result is not None
 
 
+def test_record_user_preference_persona_unknown_value_rejected():
+    from interface.server.mcp_server import record_user_preference
+    result = record_user_preference("persona", "wizard")
+    if result.get("behaviour_tracking") == "disabled":
+        return
+    assert result["recorded"] is False
+    assert "error" in result
+
+
 # ── supersede_learning ────────────────────────────────────────────────────────
 
 def test_supersede_learning_nonexistent_id():


### PR DESCRIPTION
## Summary
- Exactly 3 opt-in personas via existing `record_user_preference("persona", ...)` — zero new tools, zero schema change.
- `BehaviourTracker` validates against a reserved `_PERSONAS` registry; unknown values rejected without clobbering an existing valid one.
- `get_user_profile()` additively surfaces `active_persona`/`persona_behavior` — absent entirely when unset.

## Acceptance criteria
- [x] `record_user_preference("persona","mentor")` -> `profile.active_persona="mentor"` with its behavior block; invalid value rejected listing valid names
- [x] No persona -> golden-identical profile output (exact field-set test)
- [x] Docs name each persona's concrete deltas (retrieval depth, verbosity, tone) — CLAUDE.md, docs/USAGE.md, docs/MCP_TOOLS.md

## Test plan
- [x] Full pytest suite: 1399 passed, 5 skipped (was 1392/5 pre-story)
- [x] Manifest tokens unchanged: 3499 -> 3499
- [x] `JIRA/EPIC-MoodPersonaLayer-400/STORY/COGNIREPO-402/TEST/COGNIREPO-402-TEST_SUITE.md` — mechanics leg PASS; live-agent leg pending user's own session

🤖 Generated with [Claude Code](https://claude.com/claude-code)