### PR TITLE
COGNIREPO-502: delegation_hints surface + TODO scan + consumer docs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -58,12 +58,17 @@ jobs:
           # Audits the pinned versions in requirements.txt directly — `pip install .`
           # above resolves from pyproject.toml and does not exercise these pins, so a
           # CVE fix committed to requirements.txt could silently drift without this step.
-          # Ignore CVE-2026-45829 (chromadb pre-auth code injection via trust_remote_code on
-          # its HTTP server's /collections endpoint): CogniRepo only uses
-          # chromadb.PersistentClient (embedded, in-process — core/vector_db/chroma_adapter.py),
-          # never chromadb's HTTP server, so the vulnerable endpoint is never running.
+          # Ignore CVE-2026-45829/-45830/-45831/-45833 (chromadb): all four require chromadb's
+          # HTTP server to be running — 45829/45833 are pre-auth / update_collection code
+          # injection via trust_remote_code on the server's endpoints, 45830/45831 are
+          # SimpleRBACAuthorizationProvider multi-tenant authorization bypasses on the same
+          # server. CogniRepo only uses chromadb.PersistentClient (embedded, in-process —
+          # core/vector_db/chroma_adapter.py:60), never chromadb.HttpClient or the server
+          # process, so none of these endpoints ever run. No fix version exists yet for any of
+          # the three added here (checked via pip-audit's Fix Versions column, 2026-08-30).
           pip-audit -r requirements.txt \
-            --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829
+            --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-45829 \
+            --ignore-vuln CVE-2026-45830 --ignore-vuln CVE-2026-45831 --ignore-vuln CVE-2026-45833
 
   # ── 3. Trivy — filesystem scan ────────────────────────────────────────────
   trivy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Exactly three, each a concrete behavior delta, never a decorative label:
 | Session start | `get_session_brief()` → `get_last_context()` → `get_user_profile()` → `get_error_patterns()` |
 | Find where a function lives | `lookup_symbol("fn_name")` |
 | Understand a module or query | `context_pack("question")` |
+| `context_pack` returned `delegation_hints` (≥2 independent groups) | consider Task/subagent delegation — one subagent per group, per COGNIREPO-502 |
 | Find callers of a function | `who_calls("fn_name")` |
 | Past decisions / bugs | `episodic_search("topic")` |
 | Architecture overview | `architecture_overview()` |

--- a/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/COGNIREPO-500-D01.md
+++ b/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/COGNIREPO-500-D01.md
@@ -1,0 +1,92 @@
+# COGNIREPO-500-D01 — independence grouping over-fragments on large (weight-filtered) repos
+
+Epic: COGNIREPO-500 · Branch: defect/COGNIREPO-500-D01 · Base: development
+Found while manually testing: COGNIREPO-502 (TC-502-1)
+Does NOT block COGNIREPO-501 or COGNIREPO-502's own acceptance criteria — both pass as written.
+Blocks: epic COGNIREPO-500 sign-off (per skill.md §G.4) until resolved or explicitly deferred.
+
+## Backstory
+
+`intelligence/indexer/ast_indexer.py:1818-1826` gates full graph population (proper
+`type`/`file` node attrs + a `DEFINED_IN` symbol→FILE edge) behind
+`weight >= getattr(self, "_graph_weight_min", 0.0)` — a deliberate OOM guard for large repos
+(comment: "skipped or weight-filtered for large repos to prevent OOM"). Symbols below that
+weight still get referenced as call-graph edge endpoints elsewhere (`CALLS`/`CALLED_BY`), and
+`networkx` auto-creates the node on `add_edge()` with **zero attributes** when it doesn't
+already exist.
+
+`intelligence/retrieval/hybrid.py::_reachable_files()` (COGNIREPO-501) relies entirely on those
+attrs — `_record()` checks `data.get("type") == NodeType.FILE` or `data.get("file")` — to map a
+symbol back to its file. A node with no attrs contributes nothing to its own reachable-file set,
+and (since the `DEFINED_IN` edge was never written either) never connects to its own FILE node
+through that path either.
+
+## Repro (measured, not estimated)
+
+```
+cognirepo_test_repo/advanced/moby         77,772 nodes — 60,220 (77.4%) have zero attrs
+cognirepo_test_repo/advanced/kubernetes   76,784 nodes — 61,941 (80.7%) have zero attrs
+cognirepo_test_repo/easy/flask (Python)    1,945 nodes —      0 ( 0.0%) have zero attrs
+```
+
+Two functions confirmed in the **same file** in moby —
+`daemon/container.go::GetContainer` and `daemon/container.go::load` — were fed through the real
+(unmocked) `HybridRetriever._annotate_independence_groups()` and got **different**
+`component_id`s (`g0`/`g1`), when a same-file pair should always land in one group (same-file
+symbols share a `DEFINED_IN` edge to the same FILE node, which is exactly the case that's
+missing here). Confirmed via direct node inspection: both nodes' attrs are `{}`, and neither has
+a `DEFINED_IN` edge in either direction — only `CALLS`/`CALLED_BY` edges to other symbols, many
+of which are themselves attr-less stubs.
+
+Reproduce:
+```python
+# cwd = cognirepo_test_repo/advanced/moby (already indexed)
+from data.graph.knowledge_graph import KnowledgeGraph
+kg = KnowledgeGraph()
+n = "daemon/container.go::GetContainer"
+print(dict(kg.G.nodes[n]))                 # {}  <- should have type/file/line/weight
+print(list(kg.G.predecessors(n)))          # no DEFINED_IN edge to daemon/container.go
+```
+
+## Description
+
+Not a crash and not a ranking-safety issue — `_annotate_independence_groups` still returns
+byte-identical scores/order/status per COGNIREPO-501 AC2, it just over-fragments: on a large
+repo, most hits will get distinct `component_id`s regardless of real structural connectivity,
+because the signal `_reachable_files` depends on (node attrs + `DEFINED_IN` edges) was
+deliberately never written for the majority of nodes. This degrades COGNIREPO-501's grouping
+*and* COGNIREPO-502's `delegation_hints` (more spurious "independent" groups than are real) on
+exactly the class of repo (large, real-world) both stories were dogfooded against — 501's own
+manual test happened to use `ansible` (17.6k nodes), which is small enough that its `_graph_min`
+filter apparently doesn't trim much; it never exercised the filtered-majority case.
+
+**This needs an owner decision, not a unilateral fix** — the weight filter exists specifically
+to bound memory on large repos, and lifting it wholesale could reintroduce the OOM risk it was
+added for. Options, roughly cheapest-to-most-invasive:
+
+1. When a node is auto-created as a call-graph edge endpoint below `_graph_min`, still stamp
+   minimal `type`/`file` attrs (no embedding, no FAISS write — just a few dict keys) so
+   `_reachable_files` can use it. Cheapest; needs verifying this doesn't reintroduce the
+   original OOM pressure (the costly part was presumably embedding/FAISS writes, not attrs).
+2. Have `_record()` fall back to parsing the file path out of the node ID itself
+   (`"daemon/container.go::GetContainer"` → `"daemon/container.go"`) when attrs are missing,
+   since the ID format is already deterministic (`graph_utils.make_node_id`). Zero indexer
+   changes, but `.file` extraction. by string-split is a bit implicit relying on ID format.
+3. Leave as-is and document the limitation (grouping is best-effort/degrades on repos above
+   some node-count threshold) — cheapest of all, but means `delegation_hints` quietly gets less
+   useful exactly on the repos where subagent delegation would help most.
+
+## Acceptance criteria
+
+1. Reproduce the same-file test above post-fix: two symbols confirmed in the same file get the
+   same `component_id` on `cognirepo_test_repo/advanced/moby` (or a chosen fix's equivalent
+   evidence, if option 3/documentation-only is chosen instead).
+2. No regression to COGNIREPO-501 AC2 (byte-identical scores/order with grouping disabled) or
+   AC4 (<10ms latency budget) — re-run `tests/test_hybrid_retrieval.py`.
+3. No measurable regression in indexing memory/time on `moby`/`kubernetes` if option 1 is taken
+   (re-run indexing, compare peak RSS before/after).
+
+## Risks / notes
+
+- This is a design tradeoff (memory vs. grouping accuracy), not a straightforward bug fix —
+  flagging for the user to pick a direction before implementation starts.

--- a/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/COGNIREPO-500-D01.md
+++ b/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/COGNIREPO-500-D01.md
@@ -90,3 +90,22 @@ added for. Options, roughly cheapest-to-most-invasive:
 
 - This is a design tradeoff (memory vs. grouping accuracy), not a straightforward bug fix —
   flagging for the user to pick a direction before implementation starts.
+
+## Addendum (2026-08-30) — related cache-keying issue found while CI-debugging this ticket
+
+`_grouping_allowed()`'s `_integrity_gate_cache` (`intelligence/retrieval/hybrid.py`) is a
+single module-level dict shared by every caller in the process, with no key on which repo/graph
+it was computed for. `HybridRetriever.__init__` constructs a fresh `KnowledgeGraph()` per call,
+and `_repo_ctx()` (mcp_server.py) repoints storage at a different repo's `.cognirepo/` for
+cross-repo tool calls within the SAME long-lived MCP server process — so a cross-repo call can
+read (and serve, for up to the 300s TTL) an integrity-gate verdict that was actually computed
+against a *different* repo's graph. Confirmed as a real race (not just a test artifact) while
+fixing CI flakiness in `test_grouping_allowed_trips_on_high_orphan_count`
+(COGNIREPO-502/PR #64): the shared cache dict was observably repopulated by a concurrent
+caller between one test forcing a fresh check and that same test's own `_grouping_allowed()`
+call — the test-side fix was isolating the test onto a private dict via `monkeypatch.setattr`,
+but production code has no equivalent isolation. Likely fix: key the cache by `repo_root` (or
+`id(graph)`/a hash of the graph's disk path) instead of one flat dict. Not fixed here — flagging
+alongside the primary D01 finding since both concern this same integrity-gate mechanism, but
+this is a separate, more clear-cut correctness bug (no design tradeoff needed) rather than the
+above's memory-vs-accuracy call.

--- a/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/TEST/COGNIREPO-500-D01-TEST_SUITE.md
+++ b/JIRA/EPIC-SubagentEnrichment-500/DEFECT/COGNIREPO-D01/TEST/COGNIREPO-500-D01-TEST_SUITE.md
@@ -1,0 +1,31 @@
+# COGNIREPO-500-D01 — Manual test suite (written before the fix, per skill.md §G.1)
+
+## TC-D01-1: Same-file symbols group together on a large repo
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced/moby
+- Prerequisites: repo indexed (already is); fix direction chosen (see ticket options 1-3).
+- What to do: pick two functions confirmed in the same large Go file (e.g.
+  `daemon/container.go::GetContainer` and `daemon/container.go::load`); run them through
+  `HybridRetriever._annotate_independence_groups()` directly (unmocked, real graph).
+- Prompt: n/a — reproduced via direct Python, not a chat prompt (see ticket's Repro section for
+  the exact snippet).
+- Expected results: both symbols get the SAME `component_id` (post-fix). Currently (pre-fix)
+  they get different ids (`g0`/`g1`) — this is the defect.
+- Obtained results:
+- Verdict:
+
+## TC-D01-2: No regression to COGNIREPO-501 AC2/AC4
+- Test repo: n/a (unit suite)
+- What to do: `venv/bin/python -m pytest tests/test_hybrid_retrieval.py -q`
+- Expected results: all pass, including the byte-identical-with-grouping-disabled golden test
+  and the <10ms latency test.
+- Obtained results:
+- Verdict:
+
+## TC-D01-3: No memory/time regression on large repos (only if fix option 1 chosen)
+- Test repo: /home/ashlesh/my_works/cognirepo_test_repo/advanced/moby and /advanced/kubernetes
+- What to do: full reindex (`cognirepo index-repo .`) before and after the fix; compare peak RSS
+  and wall-clock time.
+- Expected results: no material regression (the fix should only add a few dict keys per
+  already-created edge-endpoint node, not new embedding/FAISS work).
+- Obtained results:
+- Verdict:

--- a/JIRA/EPIC-SubagentEnrichment-500/STORY/COGNIREPO-502/TEST/COGNIREPO-502-TEST_SUITE.md
+++ b/JIRA/EPIC-SubagentEnrichment-500/STORY/COGNIREPO-502/TEST/COGNIREPO-502-TEST_SUITE.md
@@ -8,5 +8,29 @@
 - Prompt: "Use context_pack for '<spanning query>'. Is any of this work parallelizable?"
 - Expected results: call 1: 2 groups + TODOs, ≤60 extra tokens; call 2: no delegation_hints key;
   call 3: hints dropped, code context preserved.
-- Obtained results:
-- Verdict:
+- Obtained results: ran directly against `cognirepo_test_repo/advanced/moby` (real indexed
+  graph, 77.7k nodes). Two structurally-unrelated real symbols —
+  `daemon/container.go::GetContainer` and `integration-cli/cli/cli.go::DockerCmd`
+  (`hop_distance` = 3, no path through the restricted structural-edge set) — fed through the
+  real `HybridRetriever._annotate_independence_groups` (unmocked) got distinct `component_id`s
+  (`g0`/`g1`); running the resulting hit dicts through the real `context_pack()` (unmocked, real
+  files, real repo_root) produced `delegation_hints` with 2 groups and real grepped
+  TODO/FIXME lines (`daemon/container.go:65,103,144` capped at 3; `integration-cli/cli/cli.go:20`).
+  Single-module query (two functions in the same file) and tight-budget (max_tokens=25, unit
+  test) verified separately — see automated coverage in `tests/test_context_pack.py::
+  TestDelegationHints` (7 cases: presence+TODOs, absence on 1 group, absence with no
+  component_id, ≤80-token cost for the 2-group case, drop-on-tight-budget with core content
+  intact, 3-TODO cap). Full automated suite: 1439 passed, 5 skipped.
+
+  **Also surfaced during this run** (filed as COGNIREPO-500-D01, does not block this story's
+  ACs — all 4 pass): on this same large real repo, the "single-module" real-world case above
+  behaved unexpectedly — two functions confirmed in the SAME file
+  (`daemon/container.go::GetContainer` and `::load`) still got DIFFERENT `component_id`s
+  instead of the same one. Root cause: `ast_indexer.py`'s weight-filtered graph population
+  (`_graph_min`, OOM guard for large repos) means ~77-81% of nodes in `moby`/`kubernetes` never
+  get a `DEFINED_IN` edge or `file`/`type` attrs at all — `_reachable_files` (hybrid.py) can't
+  connect same-file symbols through a link that was never written. Grouping still "works" (no
+  crash, no wrong ranking — AC2's byte-identical-scores guarantee holds) but over-fragments on
+  large repos: more independent groups than are structurally real. See the defect ticket for
+  full repro.
+- Verdict: PASS

--- a/JIRA/EPIC-SubagentEnrichment-500/status.yml
+++ b/JIRA/EPIC-SubagentEnrichment-500/status.yml
@@ -7,9 +7,14 @@ stories:
     pr: https://github.com/ashlesh-t/cognirepo/pull/63
     test_status: pass  # TC-501-1 + TC-501-2, both PASS
   - id: COGNIREPO-502
-    status: not-started
+    status: in-review
     branch: story/COGNIREPO-502
+    pr: null  # opened below
+    test_status: pass  # TC-502-1 PASS
+defects:
+  - id: COGNIREPO-D01
+    status: not-started
+    branch: defect/COGNIREPO-500-D01
     pr: null
     test_status: not-run
-defects: []
 epic_test_suite_status: not-run

--- a/JIRA/EPIC-SubagentEnrichment-500/status.yml
+++ b/JIRA/EPIC-SubagentEnrichment-500/status.yml
@@ -9,7 +9,7 @@ stories:
   - id: COGNIREPO-502
     status: in-review
     branch: story/COGNIREPO-502
-    pr: null  # opened below
+    pr: https://github.com/ashlesh-t/cognirepo/pull/64
     test_status: pass  # TC-502-1 PASS
 defects:
   - id: COGNIREPO-D01

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -32,6 +32,28 @@ Call this **before reading any source file**.
 `status` is always one of: `"ok"` | `"no_confident_match"` | `"index_empty"`.
 When `status == "no_confident_match"` the response also includes `"best_score"` and `"suggestion"`.
 
+**`delegation_hints`** (optional, COGNIREPO-502): present only when the packed code hits span
+≥2 structurally-independent groups — no `IMPORTS`/`CALLS`/`CALLED_BY`/`DEFINED_IN` path between
+them (per-hit `component_id`, computed in `intelligence/retrieval/hybrid.py`, COGNIREPO-501).
+Absent (not an empty list) when everything is one group, or when the knowledge-graph integrity
+gate has disabled grouping. Counted last against `max_tokens` and dropped first on overflow —
+never displaces core `sections`.
+```json
+{
+  "delegation_hints": [
+    {
+      "group": "g0",
+      "files": ["retrieval/hybrid.py"],
+      "reason": "no shared import/call path",
+      "todos": [{"file": "retrieval/hybrid.py", "line": 88, "text": "# TODO: cache this"}]
+    },
+    {"group": "g1", "files": ["cli/daemon.py"], "reason": "no shared import/call path"}
+  ]
+}
+```
+Consider delegating each group to a separate subagent rather than working the groups
+sequentially — see the tool-routing note in `CLAUDE.md`.
+
 ---
 
 ## lookup_symbol

--- a/intelligence/retrieval/hybrid.py
+++ b/intelligence/retrieval/hybrid.py
@@ -80,13 +80,17 @@ _integrity_gate_cache: dict = {"allowed": True, "ts": 0.0}
 _integrity_gate_lock = threading.Lock()
 
 
-def _grouping_allowed(graph: KnowledgeGraph) -> bool:
-    """True unless the graph's orphan/dangling counts exceed a corruption-level threshold —
-    so integrity problems never masquerade as legitimate parallelism (COGNIREPO-501 AC3)."""
-    now = time.monotonic()
-    with _integrity_gate_lock:
-        if now - _integrity_gate_cache["ts"] < _INTEGRITY_CACHE_TTL:
-            return _integrity_gate_cache["allowed"]
+def _compute_integrity_allowed(graph: KnowledgeGraph) -> bool:
+    """The actual orphan/dangling-threshold decision, with no cache and no shared state.
+
+    Split out of _grouping_allowed() so the decision logic is unit-testable in isolation
+    from the TTL cache below — that cache is one module-level dict shared by every
+    concurrent caller in the process (any HybridRetriever, in any thread), so a test call
+    racing against a genuinely concurrent one (e.g. a different test's background thread)
+    could observe THAT OTHER call's verdict rather than its own, no matter how the dict
+    itself is isolated — the race is in the cache's check-then-act window, not the object
+    identity. This function has none of that: same graph in, same answer out, always.
+    """
     try:
         from core.config.paths import get_cognirepo_dir  # pylint: disable=import-outside-toplevel
         repo_root = os.path.dirname(os.path.abspath(get_cognirepo_dir()))
@@ -106,11 +110,28 @@ def _grouping_allowed(graph: KnowledgeGraph) -> bool:
                 n_orphans, _INTEGRITY_ORPHAN_THRESHOLD,
                 n_dangling, _INTEGRITY_DANGLING_THRESHOLD,
             )
+        return allowed
     except Exception as exc:  # pylint: disable=broad-except
         # Fail open — a broken integrity check shouldn't break retrieval — but still surface
         # it, since a silently-broken check would look identical to "graph is fine".
         log.debug("hybrid: integrity_report() failed, grouping gate fails open: %s", exc)
-        allowed = True
+        return True
+
+
+def _grouping_allowed(graph: KnowledgeGraph) -> bool:
+    """True unless the graph's orphan/dangling counts exceed a corruption-level threshold —
+    so integrity problems never masquerade as legitimate parallelism (COGNIREPO-501 AC3).
+
+    TTL-caches _compute_integrity_allowed()'s result across calls — integrity_report() is
+    O(nodes), too slow to run synchronously on every hybrid_retrieve() call (see module
+    comments above). NOT keyed by graph/repo identity (see COGNIREPO-500-D01 addendum) —
+    correct for the common single-repo-per-process case, a known gap for cross-repo calls.
+    """
+    now = time.monotonic()
+    with _integrity_gate_lock:
+        if now - _integrity_gate_cache["ts"] < _INTEGRITY_CACHE_TTL:
+            return _integrity_gate_cache["allowed"]
+    allowed = _compute_integrity_allowed(graph)
     with _integrity_gate_lock:
         _integrity_gate_cache["allowed"] = allowed
         _integrity_gate_cache["ts"] = now

--- a/interface/tools/context_pack.py
+++ b/interface/tools/context_pack.py
@@ -78,12 +78,9 @@ _DOC_INTENT_PATTERN = re.compile(
 
 
 
-def _read_window(file_path: str, center_line: int, window_lines: int, repo_root: str | None = None) -> str:
-    """
-    Read ±window_lines around center_line from file_path.
-    Returns the extracted text, or empty string if the file is unreadable.
-    """
-    repo_root = repo_root or os.environ.get("COGNIREPO_ROOT", os.getcwd())
+def _safe_abs_path(file_path: str, repo_root: str) -> str | None:
+    """Resolve file_path against repo_root, refusing anything that escapes it
+    (symlink or ../ traversal). Returns the resolved absolute path, or None."""
     abs_path = (
         file_path if os.path.isabs(file_path)
         else os.path.join(repo_root, file_path)
@@ -91,6 +88,18 @@ def _read_window(file_path: str, center_line: int, window_lines: int, repo_root:
     real_abs = os.path.realpath(abs_path)
     real_root = os.path.realpath(repo_root)
     if not real_abs.startswith(real_root + os.sep) and real_abs != real_root:
+        return None
+    return real_abs
+
+
+def _read_window(file_path: str, center_line: int, window_lines: int, repo_root: str | None = None) -> str:
+    """
+    Read ±window_lines around center_line from file_path.
+    Returns the extracted text, or empty string if the file is unreadable.
+    """
+    repo_root = repo_root or os.environ.get("COGNIREPO_ROOT", os.getcwd())
+    real_abs = _safe_abs_path(file_path, repo_root)
+    if not real_abs:
         return ""
     try:
         lines = Path(real_abs).read_text(encoding="utf-8", errors="replace").splitlines()
@@ -99,6 +108,37 @@ def _read_window(file_path: str, center_line: int, window_lines: int, repo_root:
     start = max(0, center_line - window_lines - 1)
     end = min(len(lines), center_line + window_lines)
     return "\n".join(lines[start:end])
+
+
+# ── delegation hints (COGNIREPO-502) ────────────────────────────────────────────
+# ≤3 TODO/FIXME lines per independence group, grepped at pack time from the hit
+# files ONLY — no indexer/index-schema changes (Discovery §2: "pack-time grep over
+# HIT FILES ONLY keeps the index schema unchanged").
+_TODO_PATTERN = re.compile(r"\b(TODO|FIXME)\b")
+_MAX_TODOS_PER_GROUP = 3
+_MAX_TODO_LINE_LEN = 160
+
+
+def _scan_todos(files: list[str], repo_root: str) -> list[dict]:
+    """Grep the given files (already-retrieved hit files, not a repo-wide scan) for
+    TODO/FIXME lines. Stops at _MAX_TODOS_PER_GROUP total across all files."""
+    out: list[dict] = []
+    for fpath in files:
+        if len(out) >= _MAX_TODOS_PER_GROUP:
+            break
+        real_abs = _safe_abs_path(fpath, repo_root)
+        if not real_abs:
+            continue
+        try:
+            lines = Path(real_abs).read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for lineno, line in enumerate(lines, start=1):
+            if len(out) >= _MAX_TODOS_PER_GROUP:
+                break
+            if _TODO_PATTERN.search(line):
+                out.append({"file": fpath, "line": lineno, "text": line.strip()[:_MAX_TODO_LINE_LEN]})
+    return out
 
 
 def _is_doc_query(query: str) -> bool:
@@ -238,6 +278,15 @@ def context_pack(
     Optional keys when query enhancement fires:
         "enhanced_query": str,
         "enhancement_method": str
+
+    Optional key when the packed code hits span ≥2 structurally-independent groups
+    (COGNIREPO-501 component_id — no shared IMPORTS/CALLS/CALLED_BY/DEFINED_IN path):
+    dropped first if it would blow the token budget, absent entirely when there's
+    only one group (or grouping is integrity-gated off).
+        "delegation_hints": [
+            {"group": "g0", "files": [...], "reason": "no shared import/call path",
+             "todos": [{"file": ..., "line": ..., "text": ...}, ...]}  # optional, ≤3
+        ]
     """
     # ── file-mode: return all indexed context for a specific file ────────────
     if file:
@@ -253,6 +302,7 @@ def context_pack(
     token_budget = max_tokens
     truncated = False
     _cold_index = False
+    code_groups: dict[str, set[str]] = {}  # component_id -> file paths actually packed (COGNIREPO-502)
 
     # ── 0. pre-call query enhancement ────────────────────────────────────────
     _enhanced = None
@@ -384,6 +434,14 @@ def context_pack(
                 "bucket": "code" if source_label == "ast" else "doc",
             })
             token_budget -= tok
+
+            # COGNIREPO-502: track which independence group (hybrid.py's component_id)
+            # each packed code hit belongs to, for the delegation_hints pass below.
+            if is_code and file_ref:
+                comp_id = cand.get("component_id")
+                if comp_id:
+                    code_groups.setdefault(comp_id, set()).add(file_ref.rsplit(":", 1)[0])
+
             return True
 
         # ── relative-score noise gate ──────────────────────────────────────
@@ -433,6 +491,28 @@ def context_pack(
         except Exception as exc:  # pylint: disable=broad-except
             _logger.warning("episodic BM25 query failed: %s", exc)
 
+    # ── 3. delegation hints (COGNIREPO-502) ─────────────────────────────────
+    # Only when ≥2 independence groups exist among the packed code hits — absent
+    # (not an empty list) otherwise, so AC1's "connected fixture -> key ABSENT"
+    # holds without a separate on/off flag. Counted LAST against max_tokens and
+    # dropped FIRST on overflow — core sections above are never touched for this.
+    delegation_hints: list[dict] | None = None
+    if len(code_groups) >= 2:
+        _hint_root = repo_root or os.environ.get("COGNIREPO_ROOT", os.getcwd())
+        candidate_hints = []
+        for comp_id in sorted(code_groups):
+            files = sorted(code_groups[comp_id])
+            entry: dict = {"group": comp_id, "files": files, "reason": "no shared import/call path"}
+            todos = _scan_todos(files, _hint_root)
+            if todos:
+                entry["todos"] = todos
+            candidate_hints.append(entry)
+        hint_tokens = _count_tokens(json.dumps(candidate_hints))
+        if hint_tokens <= token_budget:
+            delegation_hints = candidate_hints
+            token_budget -= hint_tokens
+        # else: tight budget — drop hints entirely, core content stays intact (AC3)
+
     total_tokens = max_tokens - token_budget
     result: dict = {
         "query": query,
@@ -449,6 +529,8 @@ def context_pack(
     if include_symbols and _cold_index and not sections:
         result["status"] = "index_empty"
         result["suggestion"] = "run `cognirepo index-repo .` first"
+    if delegation_hints:
+        result["delegation_hints"] = delegation_hints
     _autosave_context(result)
     return result
 

--- a/tests/test_context_pack.py
+++ b/tests/test_context_pack.py
@@ -127,6 +127,127 @@ class TestContextPack:
             assert abs(reported - actual) / actual <= 0.05
 
 
+class TestDelegationHints:
+    """COGNIREPO-502 — delegation_hints in context_pack output."""
+
+    @staticmethod
+    def _write(tmp_path, rel_path, lines):
+        p = tmp_path / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _ast_candidate(self, rel_path, line, component_id, score=0.9):
+        return {
+            "text": f"FUNCTION fn in {rel_path}:{line} — helper",
+            "final_score": score,
+            "source": "ast",
+            "component_id": component_id,
+        }
+
+    def test_present_with_todos_for_two_groups(self, tmp_path):
+        """AC1: two-group fixture -> hints present, each with its TODO/FIXME lines."""
+        from interface.tools.context_pack import context_pack
+
+        self._write(tmp_path, "mod_a.py", ["def a():", "    pass", "    # TODO: refactor this"])
+        self._write(tmp_path, "mod_b.py", ["def b():", "    pass", "    # FIXME: handle edge case"])
+        candidates = [
+            self._ast_candidate("mod_a.py", 1, "g0"),
+            self._ast_candidate("mod_b.py", 1, "g1"),
+        ]
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path))
+
+        hints = result.get("delegation_hints")
+        assert hints is not None
+        assert {h["group"] for h in hints} == {"g0", "g1"}
+        for h in hints:
+            assert h["reason"] == "no shared import/call path"
+            assert h["files"]
+        by_group = {h["group"]: h for h in hints}
+        assert by_group["g0"]["todos"][0]["text"].endswith("TODO: refactor this")
+        assert by_group["g1"]["todos"][0]["text"].endswith("FIXME: handle edge case")
+
+    def test_absent_when_single_group(self, tmp_path):
+        """AC1: connected fixture (one component_id) -> key absent entirely, not an empty list."""
+        from interface.tools.context_pack import context_pack
+
+        self._write(tmp_path, "mod_a.py", ["def a():", "    pass"])
+        self._write(tmp_path, "mod_b.py", ["def b():", "    pass"])
+        candidates = [
+            self._ast_candidate("mod_a.py", 1, "g0"),
+            self._ast_candidate("mod_b.py", 1, "g0"),
+        ]
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path))
+        assert "delegation_hints" not in result
+
+    def test_absent_when_no_component_id(self, tmp_path):
+        """Hits with no resolvable component_id (grouping gated off, or non-graph hits) never
+        produce hints — matches hybrid.py's "no key at all" contract, not an empty groups dict."""
+        from interface.tools.context_pack import context_pack
+
+        self._write(tmp_path, "mod_a.py", ["def a():", "    pass"])
+        candidates = [
+            {"text": f"FUNCTION fn in mod_a.py:1 — helper", "final_score": 0.9, "source": "ast"},
+        ]
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path))
+        assert "delegation_hints" not in result
+
+    def test_two_group_token_cost_is_small(self, tmp_path):
+        """AC2: added output for the two-group case stays in the few-dozen-token budget."""
+        from interface.tools.context_pack import context_pack, _count_tokens
+        import json
+
+        self._write(tmp_path, "mod_a.py", ["def a():", "    pass"])
+        self._write(tmp_path, "mod_b.py", ["def b():", "    pass"])
+        candidates = [
+            self._ast_candidate("mod_a.py", 1, "g0"),
+            self._ast_candidate("mod_b.py", 1, "g1"),
+        ]
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path))
+        hints = result["delegation_hints"]
+        assert _count_tokens(json.dumps(hints)) <= 80  # ~60 tokens expected, generous margin
+
+    def test_dropped_on_tight_budget_core_content_intact(self, tmp_path):
+        """AC3: a budget too tight for hints drops them silently — core sections still pack."""
+        from interface.tools.context_pack import context_pack
+
+        self._write(tmp_path, "mod_a.py", ["def a():", "    pass", "    # TODO: one"])
+        self._write(tmp_path, "mod_b.py", ["def b():", "    pass", "    # TODO: two"])
+        candidates = [
+            self._ast_candidate("mod_a.py", 1, "g0"),
+            self._ast_candidate("mod_b.py", 1, "g1"),
+        ]
+        # Enough budget for the two small code sections, not enough left over for hints.
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path), max_tokens=25)
+        assert "delegation_hints" not in result
+        assert len(result["sections"]) >= 1  # core content untouched by the drop
+
+    def test_todos_capped_at_three_per_group(self, tmp_path):
+        lines = ["def a():"] + [f"    # TODO: item {i}" for i in range(6)]
+        self._write(tmp_path, "mod_a.py", lines)
+        self._write(tmp_path, "mod_b.py", ["def b():", "    pass"])
+        from interface.tools.context_pack import context_pack
+
+        candidates = [
+            self._ast_candidate("mod_a.py", 1, "g0"),
+            self._ast_candidate("mod_b.py", 1, "g1"),
+        ]
+        with patch("interface.tools.context_pack.hybrid_retrieve", return_value=candidates):
+            with patch("interface.tools.context_pack.episodic_bm25_filter", return_value=[]):
+                result = context_pack("query", repo_root=str(tmp_path))
+        by_group = {h["group"]: h for h in result["delegation_hints"]}
+        assert len(by_group["g0"]["todos"]) == 3
+
+
 class TestContextPackRepoPaths:
     def test_context_pack_with_repo_path_returns_valid_shape(self, isolated_cognirepo, tmp_path):
         """MCP context_pack(repo_path=...) must return structured result, not crash."""

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -272,47 +272,51 @@ class TestIndependenceGrouping:
         assert len(reached) <= hybrid_mod._GROUPING_MAX_VISITED
 
     def test_grouping_allowed_on_clean_graph(self, tmp_path, monkeypatch):
-        """_grouping_allowed itself (not mocked) returns True for a graph with no orphans."""
+        """_compute_integrity_allowed (the decision _grouping_allowed caches) returns True
+        for a graph with no orphans.
+
+        Calls _compute_integrity_allowed() directly rather than the cached _grouping_allowed()
+        wrapper — see test_grouping_allowed_trips_on_high_orphan_count below for why: the
+        wrapper's TTL cache is one module-level dict shared by every concurrent caller in the
+        process, and no amount of isolating the dict object closes the race, since the cache
+        stores a per-CALL verdict with no notion of which graph it came from.
+        """
         from intelligence.retrieval import hybrid as hybrid_mod
         from intelligence.retrieval.hybrid import HybridRetriever
 
-        # A fresh dict, not a mutation of the shared module-level cache: _grouping_allowed's
-        # own local `allowed` is what it returns, but its FIRST check reads
-        # _integrity_gate_cache["ts"] under a lock — if any other thread in this process
-        # (e.g. a leftover background-reindex/watcher daemon thread from an earlier test)
-        # concurrently calls _grouping_allowed() on an unrelated graph, it can repopulate the
-        # SHARED cache with a fresh timestamp between this test setting ts=0.0 and its own
-        # call, causing THIS call to short-circuit into returning THAT unrelated result
-        # instead of computing its own — see test_grouping_allowed_trips_on_high_orphan_count
-        # for where this was actually observed. Swapping in a private dict object closes that
-        # race entirely: nothing else in the process can be holding a reference to it.
-        monkeypatch.setattr(hybrid_mod, "_integrity_gate_cache", {"allowed": True, "ts": 0.0})
-        (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
-        # See test_grouping_allowed_trips_on_high_orphan_count below for why
-        # get_cognirepo_dir() is patched directly rather than relying on the env var.
-        import core.config.paths as _paths_mod
-        monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
-        r = HybridRetriever()
-        assert hybrid_mod._grouping_allowed(r.graph) is True
-
-    def test_grouping_allowed_trips_on_high_orphan_count(self, tmp_path, monkeypatch, caplog):
-        """AC3: a graph past the corruption-level orphan threshold gates grouping off,
-        and the trip is logged (not silent) — see PR #63 review discussion."""
-        from data.graph.knowledge_graph import NodeType
-        from intelligence.retrieval import hybrid as hybrid_mod
-        from intelligence.retrieval.hybrid import HybridRetriever
-
-        # Private cache dict, not a mutation of the shared module-level one — see the
-        # docstring note in test_grouping_allowed_on_clean_graph above for the concurrent-
-        # caller race this closes (observed on CI: this exact assertion flaked with
-        # "assert True is False" even with ts forced to 0.0, because a background thread
-        # elsewhere in the same worker process repopulated the SHARED cache with an unrelated
-        # graph's fresh result in between).
-        monkeypatch.setattr(hybrid_mod, "_integrity_gate_cache", {"allowed": True, "ts": 0.0})
         (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
         # get_cognirepo_dir() checks a ContextVar before the COGNIREPO_DIR env var (used by
         # CrossRepoRouter for thread safety) — patch it directly so repo_root resolution can't
         # be affected by ambient state either.
+        import core.config.paths as _paths_mod
+        monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
+        r = HybridRetriever()
+        assert hybrid_mod._compute_integrity_allowed(r.graph) is True
+
+    def test_grouping_allowed_trips_on_high_orphan_count(self, tmp_path, monkeypatch, caplog):
+        """AC3: a graph past the corruption-level orphan threshold gates grouping off,
+        and the trip is logged (not silent) — see PR #63 review discussion.
+
+        Calls _compute_integrity_allowed() directly, not the cached _grouping_allowed()
+        wrapper. This assertion originally flaked on CI (push-triggered runs only) with
+        "assert True is False" even after isolating _integrity_gate_cache to a private dict —
+        because _grouping_allowed's cache is a single module-level dict storing one verdict for
+        ANY graph any concurrent caller passes it (any HybridRetriever, any thread, in the same
+        process); a genuinely concurrent caller (e.g. another test's background thread, or
+        pytest-xdist scheduling this test right after one) racing the cache's check-then-act
+        window can have ITS verdict read back for THIS graph, no matter whose dict object it
+        is. _compute_integrity_allowed has no cache and no shared state — same graph in, same
+        answer out, always; this is what actually needed testing for AC3, and it's what
+        _grouping_allowed's cache wraps (test_grouping_allowed_caches_result below covers the
+        wrapper's TTL behavior with a MagicMock graph, which was never part of the flake).
+        Also documented as a real production gap in COGNIREPO-500-D01's addendum (the cache
+        should be keyed by repo/graph identity — not fixed here).
+        """
+        from data.graph.knowledge_graph import NodeType
+        from intelligence.retrieval import hybrid as hybrid_mod
+        from intelligence.retrieval.hybrid import HybridRetriever
+
+        (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
         import core.config.paths as _paths_mod
         monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
         r = HybridRetriever()
@@ -322,7 +326,7 @@ class TestIndependenceGrouping:
             r.graph.add_node(f"orphan{i}.py", NodeType.FILE, file=f"orphan{i}.py")
 
         with caplog.at_level("WARNING", logger=hybrid_mod.log.name):
-            allowed = hybrid_mod._grouping_allowed(r.graph)
+            allowed = hybrid_mod._compute_integrity_allowed(r.graph)
         assert allowed is False
         assert "independence grouping disabled" in caplog.text
 
@@ -336,6 +340,52 @@ class TestIndependenceGrouping:
         fake_graph = MagicMock()
         assert hybrid_mod._grouping_allowed(fake_graph) is True
         fake_graph.integrity_report.assert_not_called()
+
+    def test_grouping_allowed_cache_not_keyed_by_graph(self, tmp_path, monkeypatch):
+        """Documents the known gap behind COGNIREPO-500-D01's addendum and the CI flake that
+        led to _compute_integrity_allowed being split out: _grouping_allowed's TTL cache is
+        one module-level dict for the whole process, with no notion of WHICH graph a verdict
+        was computed for. Two concurrent callers with different graphs (a healthy one, a
+        corrupt one) can have the corrupt one's caller read back the healthy one's cached
+        verdict — reproduced here directly rather than asserted as "sometimes flaky"."""
+        import threading
+        import networkx as nx
+        from data.graph.knowledge_graph import NodeType
+        from intelligence.retrieval import hybrid as hybrid_mod
+
+        import core.config.paths as _paths_mod
+        (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
+        monkeypatch.setattr(hybrid_mod, "_integrity_gate_cache", {"allowed": True, "ts": 0.0})
+
+        healthy = hybrid_mod.KnowledgeGraph.__new__(hybrid_mod.KnowledgeGraph)
+        healthy.G = nx.DiGraph()
+        corrupt = hybrid_mod.KnowledgeGraph.__new__(hybrid_mod.KnowledgeGraph)
+        corrupt.G = nx.DiGraph()
+        for i in range(hybrid_mod._INTEGRITY_ORPHAN_THRESHOLD + 1):
+            corrupt.add_node(f"orphan{i}.py", NodeType.FILE, file=f"orphan{i}.py")
+
+        results = {}
+
+        def _call_corrupt():
+            # Give the healthy call a head start so it wins the cache write —
+            # deterministic ordering, not a hope-it-races timing gamble.
+            import time as _time
+            _time.sleep(0.02)
+            results["corrupt"] = hybrid_mod._grouping_allowed(corrupt)
+
+        t_healthy = threading.Thread(target=lambda: hybrid_mod._grouping_allowed(healthy))
+        t_corrupt = threading.Thread(target=_call_corrupt)
+        t_healthy.start()
+        t_corrupt.start()
+        t_healthy.join()
+        t_corrupt.join()
+
+        # The known-bad behavior: the corrupt graph's caller reads back the healthy graph's
+        # cached True instead of computing its own False. This is what makes
+        # _compute_integrity_allowed() (tested directly above, no cache involved) the right
+        # thing for AC3 correctness tests to call instead of this cached wrapper.
+        assert results["corrupt"] is True  # documents the gap; not the desired behavior
 
     def test_annotate_independence_groups_latency(self, monkeypatch):
         """AC4: added latency < 10ms for k <= 10 on a small synthetic graph."""

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -276,7 +276,17 @@ class TestIndependenceGrouping:
         from intelligence.retrieval import hybrid as hybrid_mod
         from intelligence.retrieval.hybrid import HybridRetriever
 
-        hybrid_mod._integrity_gate_cache["ts"] = 0.0  # force a fresh check
+        # A fresh dict, not a mutation of the shared module-level cache: _grouping_allowed's
+        # own local `allowed` is what it returns, but its FIRST check reads
+        # _integrity_gate_cache["ts"] under a lock — if any other thread in this process
+        # (e.g. a leftover background-reindex/watcher daemon thread from an earlier test)
+        # concurrently calls _grouping_allowed() on an unrelated graph, it can repopulate the
+        # SHARED cache with a fresh timestamp between this test setting ts=0.0 and its own
+        # call, causing THIS call to short-circuit into returning THAT unrelated result
+        # instead of computing its own — see test_grouping_allowed_trips_on_high_orphan_count
+        # for where this was actually observed. Swapping in a private dict object closes that
+        # race entirely: nothing else in the process can be holding a reference to it.
+        monkeypatch.setattr(hybrid_mod, "_integrity_gate_cache", {"allowed": True, "ts": 0.0})
         (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
         # See test_grouping_allowed_trips_on_high_orphan_count below for why
         # get_cognirepo_dir() is patched directly rather than relying on the env var.
@@ -292,15 +302,17 @@ class TestIndependenceGrouping:
         from intelligence.retrieval import hybrid as hybrid_mod
         from intelligence.retrieval.hybrid import HybridRetriever
 
-        hybrid_mod._integrity_gate_cache["ts"] = 0.0  # force a fresh check
+        # Private cache dict, not a mutation of the shared module-level one — see the
+        # docstring note in test_grouping_allowed_on_clean_graph above for the concurrent-
+        # caller race this closes (observed on CI: this exact assertion flaked with
+        # "assert True is False" even with ts forced to 0.0, because a background thread
+        # elsewhere in the same worker process repopulated the SHARED cache with an unrelated
+        # graph's fresh result in between).
+        monkeypatch.setattr(hybrid_mod, "_integrity_gate_cache", {"allowed": True, "ts": 0.0})
         (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
         # get_cognirepo_dir() checks a ContextVar before the COGNIREPO_DIR env var (used by
-        # CrossRepoRouter for thread safety). Under pytest-xdist, if any earlier test in this
-        # worker leaves that ContextVar set, monkeypatch.setenv() below is silently ignored and
-        # _grouping_allowed()'s repo_root ends up pointing at an unrelated directory — observed
-        # as a flaky CI failure (assert True is False) that didn't reproduce locally or on every
-        # CI run of the same commit. Patching get_cognirepo_dir() itself makes this test's
-        # result independent of what ran before it in the same worker.
+        # CrossRepoRouter for thread safety) — patch it directly so repo_root resolution can't
+        # be affected by ambient state either.
         import core.config.paths as _paths_mod
         monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
         r = HybridRetriever()

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -277,8 +277,11 @@ class TestIndependenceGrouping:
         from intelligence.retrieval.hybrid import HybridRetriever
 
         hybrid_mod._integrity_gate_cache["ts"] = 0.0  # force a fresh check
-        monkeypatch.setenv("COGNIREPO_DIR", str(tmp_path / ".cognirepo"))
         (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
+        # See test_grouping_allowed_trips_on_high_orphan_count below for why
+        # get_cognirepo_dir() is patched directly rather than relying on the env var.
+        import core.config.paths as _paths_mod
+        monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
         r = HybridRetriever()
         assert hybrid_mod._grouping_allowed(r.graph) is True
 
@@ -290,8 +293,16 @@ class TestIndependenceGrouping:
         from intelligence.retrieval.hybrid import HybridRetriever
 
         hybrid_mod._integrity_gate_cache["ts"] = 0.0  # force a fresh check
-        monkeypatch.setenv("COGNIREPO_DIR", str(tmp_path / ".cognirepo"))
         (tmp_path / ".cognirepo").mkdir(parents=True, exist_ok=True)
+        # get_cognirepo_dir() checks a ContextVar before the COGNIREPO_DIR env var (used by
+        # CrossRepoRouter for thread safety). Under pytest-xdist, if any earlier test in this
+        # worker leaves that ContextVar set, monkeypatch.setenv() below is silently ignored and
+        # _grouping_allowed()'s repo_root ends up pointing at an unrelated directory — observed
+        # as a flaky CI failure (assert True is False) that didn't reproduce locally or on every
+        # CI run of the same commit. Patching get_cognirepo_dir() itself makes this test's
+        # result independent of what ran before it in the same worker.
+        import core.config.paths as _paths_mod
+        monkeypatch.setattr(_paths_mod, "get_cognirepo_dir", lambda: str(tmp_path / ".cognirepo"))
         r = HybridRetriever()
         # Degree-0 FILE nodes with no incident edges — exactly what integrity_report()
         # counts as orphans. One past the threshold is enough to trip the gate.


### PR DESCRIPTION
## Summary
- `context_pack()` now groups packed code hits by hybrid.py's `component_id` (COGNIREPO-501); when ≥2 independence groups exist, appends `delegation_hints: [{group, files, reason}]` plus ≤3 TODO/FIXME lines per group, grepped from the hit files at pack time only — no indexer/index-schema changes.
- Absent entirely (not an empty list) when there's only one group, or grouping is integrity-gated off — matches AC1's byte-identical-when-disabled contract without a config flag.
- Counted **last** against `max_tokens`, dropped **first** on overflow — core `sections` are never displaced.
- Zero new MCP tools → zero manifest-token growth.
- `docs/MCP_TOOLS.md` and `CLAUDE.md`'s tool-routing table updated per AC4.

## Acceptance criteria
- [x] AC1 — two-group fixture ⇒ hints present with TODOs; connected fixture ⇒ key absent (`tests/test_context_pack.py::TestDelegationHints`, + real end-to-end run against `cognirepo_test_repo/advanced/moby`, see manual suite)
- [x] AC2 — added output ≤ ~60 tokens for the two-group case (tested ≤80 as a generous margin)
- [x] AC3 — tight budget ⇒ hints dropped, core content intact
- [x] AC4 — `docs/MCP_TOOLS.md` + `CLAUDE.md` updated

## Also filed
COGNIREPO-500-D01 — dogfooding against the real moby/kubernetes indexes (77–81% of nodes weight-filtered out of full graph population, per `ast_indexer.py`'s OOM guard for large repos) showed independence grouping over-fragmenting: same-file symbols got different `component_id`s because the attrs/`DEFINED_IN` edge `_reachable_files()` needs were never written for low-weight nodes. Doesn't violate 501 or 502's own ACs (both pass as written), but is a real accuracy gap on large repos — flagged for an owner decision (memory-vs-accuracy tradeoff) before fixing, not fixed in this PR.

## Test plan
- [x] `venv/bin/python -m pytest tests/test_context_pack.py -q` — 18 passed
- [x] `venv/bin/python -m pytest tests/ -q` — 1439 passed, 5 skipped
- [x] Manual TC-502-1 — real end-to-end run against `cognirepo_test_repo/advanced/moby` (see `JIRA/EPIC-SubagentEnrichment-500/STORY/COGNIREPO-502/TEST/COGNIREPO-502-TEST_SUITE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)